### PR TITLE
fix: Removed the UP! reaction for messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "becca_lyria",
-  "version": "13.3.0",
+  "version": "13.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "becca_lyria",
-      "version": "13.3.0",
+      "version": "13.3.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@sentry/integrations": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "becca_lyria",
   "author": "Nicholas Carrigan",
   "main": "./prod/src/main.js",
-  "version": "13.3.0",
+  "version": "13.3.1",
   "license": "AGPL-3.0-or-later",
   "private": false,
   "engines": {

--- a/src/listeners/levelsListener.ts
+++ b/src/listeners/levelsListener.ts
@@ -104,9 +104,6 @@ const levelListener: ListenerInt = {
       // Save the points and last seen to the database.
       server.markModified("users");
       await server.save();
-      if (!message.deleted) {
-        await message.react("🆙");
-      }
     } catch (error) {
       await beccaErrorHandler(
         error,


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:
This PR will remove the "UP!" (:up:) reaction of the bot to the messages which have fetched the experience points to the user.

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #666

## Scope:

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [x] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [ ] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation:

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [x] My contribution DOES require a documentation update.
