### PR TITLE
feat: link message ping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "becca_lyria",
-  "version": "15.4.0",
+  "version": "15.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "becca_lyria",
-      "version": "15.4.0",
+      "version": "15.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@sentry/integrations": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "becca_lyria",
   "author": "Nicholas Carrigan",
   "main": "./prod/src/main.js",
-  "version": "15.4.0",
+  "version": "15.5.0",
   "license": "AGPL-3.0-or-later",
   "private": false,
   "engines": {

--- a/src/config/database/defaultServer.ts
+++ b/src/config/database/defaultServer.ts
@@ -22,7 +22,8 @@ export const defaultServer = {
   permit_links: [] as string[],
   link_roles: [] as string[],
   allowed_links: [] as string[],
-  link_message: "It seems you are not allowed to send links in this channel.",
+  link_message:
+    "{@username}, it seems you are not allowed to send links in this channel.",
   level_roles: [] as LevelRoleInt[],
   join_role: "",
 };

--- a/src/listeners/linksListener.ts
+++ b/src/listeners/linksListener.ts
@@ -1,3 +1,4 @@
+import { MessageEmbed } from "discord.js";
 import { defaultServer } from "../config/database/defaultServer";
 import { ListenerInt } from "../interfaces/listeners/ListenerInt";
 import { beccaErrorHandler } from "../utils/beccaErrorHandler";
@@ -48,9 +49,20 @@ export const linksListener: ListenerInt = {
 
       if (blockedLinks > 0 && blockedLinks !== allowedLinks) {
         message.deletable && (await message.delete());
-        await message.channel.send(
-          config.link_message || defaultServer.link_message
+        const linkEmbed = new MessageEmbed();
+        linkEmbed.setTitle("Invalid Link Detected!");
+        linkEmbed.setDescription(
+          (config.link_message || defaultServer.link_message).replace(
+            /\{@username\}/g,
+            `<@!${message.author.id}>`
+          )
         );
+        linkEmbed.setColor(Becca.colours.error);
+        linkEmbed.setAuthor(
+          `${message.author.username}#${message.author.discriminator}`,
+          message.author.displayAvatarURL()
+        );
+        await message.channel.send({ embeds: [linkEmbed] });
       }
     } catch (err) {
       beccaErrorHandler(


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://github.com/BeccaLyria/discord-bot/blob/main/CONTRIBUTING.md -->

## Description

Converts anti-link message to an embed, updates `link_message` to allow `{@username}` for ping replacement.
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #724 
(for real this time!)

## Scope

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [X] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [ ] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [ ] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [X] My contribution DOES require a documentation update.
