### PR TITLE
fix: username not showing up when someone leaves

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "becca_lyria",
-  "version": "16.3.0",
+  "version": "16.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "becca_lyria",
   "author": "Nicholas Carrigan",
   "main": "./prod/src/main.js",
-  "version": "16.3.0",
+  "version": "16.3.1",
   "license": "AGPL-3.0-or-later",
   "private": false,
   "engines": {

--- a/src/events/memberEvents/memberRemove.ts
+++ b/src/events/memberEvents/memberRemove.ts
@@ -31,7 +31,7 @@ export const memberRemove = async (
     goodbyeEmbed.setColor(Becca.colours.default);
     goodbyeEmbed.setDescription(
       (serverConfig?.leave_message || defaultServer.leave_message)
-        .replace(/\{@username\}/g, `<@!${member.id}>`)
+        .replace(/\{@username\}/g, `<@!${member.user.tag}>`)
         .replace(/\{@servername\}/g, guild.name)
     );
     goodbyeEmbed.addField("Name", nickname || user.username);


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://github.com/BeccaLyria/discord-bot/blob/main/CONTRIBUTING.md -->

## Description

- Fix leaving messages not showing up the username.

This is how it currently looks.

![image](https://user-images.githubusercontent.com/51391473/130543777-341e76ef-8d1d-4d32-84a5-d071bab71308.png)

Tested with another bot, this is how it looks with this PR.

![image](https://user-images.githubusercontent.com/51391473/128413255-22c3c435-953c-4284-bd01-6d5ea59fae1f.png)

> This is because the event [`guildMemberRemove`](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-guildMemberRemove) emits a [`GuildMember`](https://discord.js.org/#/docs/main/stable/class/GuildMember) object. Since the user has already left the server (and therefore, is no longer a `GuildMember`), the ping does not work. **[@raklaptudirm](https://github.com/raklaptudirm)'s quote.**

## Scope

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [x] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [ ] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
