### PR TITLE
fix: regex allow file extensions (#752)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "becca_lyria",
   "author": "Nicholas Carrigan",
   "main": "./prod/src/main.js",
-  "version": "16.3.0",
+  "version": "16.3.1",
   "license": "AGPL-3.0-or-later",
   "private": false,
   "engines": {

--- a/src/listeners/linksListener.ts
+++ b/src/listeners/linksListener.ts
@@ -43,7 +43,7 @@ export const linksListener: ListenerInt = {
 
       // Borrowed from https://gist.github.com/arbales/1654670
       const linkRegex =
-        /(([a-z]+:\/\/)?(([a-z0-9-]+\.)+([a-z]{2,3}|aero|arpa|coop|info|jobs|museum|name|nato|travel|local|internal))(:[0-9]{1,5})?(\/[a-z0-9_\-.~]+)*(\/([a-z0-9_\-.]*)(\?[a-z0-9+_\-.%=&amp;]*)?)?(#[a-zA-Z0-9!$&'()*+.=-_~:@/?]*)?)(\s+|$)/gi;
+        /(([a-z]+:\/\/)?(([a-z0-9-]+\.)+((?!txt|md|js|ts)[a-z]{2,3}|aero|arpa|coop|info|jobs|museum|name|nato|travel|local|internal|))(:[0-9]{1,5})?(\/[a-z0-9_\-.~]+)*(\/([a-z0-9_\-.]*)(\?[a-z0-9+_\-.%=&amp;]*)?)?(#[a-zA-Z0-9!$&'()*+.=-_~:@/?]*)?)(\s+|$)/gi;
 
       blockedLinks += (message.content.match(linkRegex) || []).length;
 


### PR DESCRIPTION
## Description

File extension like `.txt` are not allowed, as they are detected as links.

## Related Issue

closes #752 

## Scope

Did you remember to update the `package.json` version number? 

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [x] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [ ] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.

Usage example...

<img width="1086" alt="Screenshot 2021-08-24 at 22 01 06" src="https://user-images.githubusercontent.com/624760/130689555-7378918d-f175-4376-b41c-0cd3ef787b63.png">


