### PR TITLE
Feat: version field added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 config.json
 /prod/
 /.nyc_output/
-.idea
+
 # Local eval command for debugging, should NEVER make it to production
 src/commands/bot/exec.ts

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 config.json
 /prod/
 /.nyc_output/
-
+.idea
 # Local eval command for debugging, should NEVER make it to production
 src/commands/bot/exec.ts

--- a/src/modules/commands/subcommands/becca/handleUpdates.ts
+++ b/src/modules/commands/subcommands/becca/handleUpdates.ts
@@ -21,6 +21,10 @@ export const handleUpdates: CommandHandler = async (Becca, interaction) => {
       "Becca's updates are deployed every Monday at 10AM Pacific Time. This is important information to know, as these deployments clear the cache. This results in any outstanding cache-reliant features, such as polls, trivia games, or scheduled posts, to be lost. Please plan your interactions around this schedule."
     );
     updateEmbed.addField("Latest Updates", updatesSinceLastRelease.join("\n"));
+    updateEmbed.addField(
+        "Current Version",
+        process.env.npm_package_version || "0.0.0"
+    );
     updateEmbed.addField("Next Scheduled Update", nextScheduledRelease);
     updateEmbed.addField(
       "Changelog",

--- a/src/modules/commands/subcommands/becca/handleUpdates.ts
+++ b/src/modules/commands/subcommands/becca/handleUpdates.ts
@@ -22,8 +22,8 @@ export const handleUpdates: CommandHandler = async (Becca, interaction) => {
     );
     updateEmbed.addField("Latest Updates", updatesSinceLastRelease.join("\n"));
     updateEmbed.addField(
-        "Current Version",
-        process.env.npm_package_version || "0.0.0"
+      "Current Version",
+      process.env.npm_package_version || "0.0.0"
     );
     updateEmbed.addField("Next Scheduled Update", nextScheduledRelease);
     updateEmbed.addField(


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://github.com/BeccaLyria/discord-bot/blob/main/CONTRIBUTING.md -->

## Description

A new field is added so that whenever we run` \becca updates` we see the current version.
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #835 

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
