### PR TITLE
Changed the link of contributing guidlines in the PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Pull Request
 
-<!-- Before contributing, please read our contributing guidelines https://github.com/BeccaLyria/discord-bot/blob/main/CONTRIBUTING.md -->
+<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute.md -->
 
 ## Description
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Pull Request
 
-<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute.md -->
+<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->
 
 ## Description
 


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://github.com/BeccaLyria/discord-bot/blob/main/CONTRIBUTING.md -->

## Description

Changed the link of contributing guidelines from CONTRIBUTING.md to the [contribute.md](https://docs.beccalyria.com/#/contribute.md) from the docs in the `PULL_REQUEST_TEMPLATE.md`
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #869 

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
