### PR TITLE
feat: emote-only channels

### DIFF
--- a/src/config/commands/settingsChoices.ts
+++ b/src/config/commands/settingsChoices.ts
@@ -23,6 +23,7 @@ export const configChoices: [string, Settings][] = [
   ["Report Channel", "report_channel"],
   ["No Levelling Channels", "level_ignore"],
   ["Sass Mode", "sass_mode"],
+  ["Emote-Only Channels", "emote_channels"],
 ];
 
 export const configViewChoices: [string, ArraySettings | "global"][] = [
@@ -33,6 +34,7 @@ export const configViewChoices: [string, ArraySettings | "global"][] = [
   ["Blocked Users", "blocked"],
   ["Level-assigned Roles", "level_roles"],
   ["No Levelling Channels", "level_ignore"],
+  ["Emote-Only Channels", "emote_channels"],
 ];
 
 export const logChoices: [string, LogSettings][] = [

--- a/src/config/database/defaultServer.ts
+++ b/src/config/database/defaultServer.ts
@@ -40,4 +40,5 @@ export const defaultServer = {
   profanity: "off",
   profanity_message:
     "{@username}, your message appears to have been inappropriate. I removed it.",
+  emote_channels: [] as string[],
 };

--- a/src/database/models/ServerConfigModel.ts
+++ b/src/database/models/ServerConfigModel.ts
@@ -26,6 +26,7 @@ export const ServerConfigSchema = new Schema({
   level_ignore: [String],
   sass_mode: String,
   triggers: Array,
+  emote_channels: Array,
   // automod
   automod_channels: [String],
   no_automod_channels: [String],

--- a/src/events/messageEvents/messageCreate.ts
+++ b/src/events/messageEvents/messageCreate.ts
@@ -2,6 +2,7 @@ import { Message } from "discord.js";
 
 import { BeccaLyria } from "../../interfaces/BeccaLyria";
 import { automodListener } from "../../listeners/automodListener";
+import { emoteListener } from "../../listeners/emoteListener";
 import { heartsListener } from "../../listeners/heartsListener";
 import { levelListener } from "../../listeners/levelListener";
 import { sassListener } from "../../listeners/sassListener";
@@ -43,6 +44,7 @@ export const messageCreate = async (
     await levelListener.run(Becca, message, serverConfig);
     await sassListener.run(Becca, message, serverConfig);
     await triggerListener.run(Becca, message, serverConfig);
+    await emoteListener.run(Becca, message, serverConfig);
 
     if (
       message.author.id === Becca.configs.ownerId &&

--- a/src/interfaces/database/ServerConfig.ts
+++ b/src/interfaces/database/ServerConfig.ts
@@ -36,6 +36,7 @@ export interface ServerConfig extends Document {
   links: string;
   profanity: string;
   profanity_message: string;
+  emote_channels: string[];
 }
 
 export const testServerConfig: Omit<ServerConfig, keyof Document> = {
@@ -71,4 +72,5 @@ export const testServerConfig: Omit<ServerConfig, keyof Document> = {
   links: "",
   profanity: "",
   profanity_message: "",
+  emote_channels: [],
 };

--- a/src/interfaces/settings/ArraySettings.ts
+++ b/src/interfaces/settings/ArraySettings.ts
@@ -10,4 +10,5 @@ export type ArraySettings =
   | "automod_roles"
   | "allowed_links"
   | "level_roles"
-  | "level_ignore";
+  | "level_ignore"
+  | "emote_channels";

--- a/src/interfaces/settings/Settings.ts
+++ b/src/interfaces/settings/Settings.ts
@@ -31,4 +31,5 @@ export type Settings =
   | "member_events"
   | "links"
   | "profanity"
-  | "profanity_message";
+  | "profanity_message"
+  | "emote_channels";

--- a/src/listeners/emoteListener.ts
+++ b/src/listeners/emoteListener.ts
@@ -1,0 +1,39 @@
+/* eslint-disable jsdoc/require-jsdoc */
+import { Listener } from "../interfaces/listeners/Listener";
+import { beccaErrorHandler } from "../utils/beccaErrorHandler";
+
+export const emoteListener: Listener = {
+  name: "emoteListener",
+  description: "Handles the logic for emote-only channels.",
+  run: async (Becca, message, config) => {
+    try {
+      if (!config.emote_channels?.includes(message.channel.id)) {
+        return;
+      }
+
+      if (!message.content) {
+        await message.delete();
+        return;
+      }
+
+      const newContent = message.content
+        ?.replace(/:[^:\s]+:|<:[^:\s]+:[0-9]+>|<a:[^:\s]+:[0-9]+>/g, "")
+        .replace(/\s/g, "");
+
+      console.table({ newContent });
+
+      if (newContent?.length) {
+        await message.delete();
+        return;
+      }
+    } catch (err) {
+      await beccaErrorHandler(
+        Becca,
+        "trigger listener",
+        err,
+        message.guild?.name,
+        message
+      );
+    }
+  },
+};

--- a/src/listeners/emoteListener.ts
+++ b/src/listeners/emoteListener.ts
@@ -22,10 +22,14 @@ export const emoteListener: Listener = {
       }
 
       const newContent = message.content
+        // Discord emote syntax
         ?.replace(/:[^:\s]+:|<:[^:\s]+:[0-9]+>|<a:[^:\s]+:[0-9]+>/g, "")
+        // standard emotes
+        .replace(
+          /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g,
+          ""
+        )
         .replace(/\s/g, "");
-
-      console.table({ newContent });
 
       if (newContent?.length) {
         await message.delete();

--- a/src/listeners/emoteListener.ts
+++ b/src/listeners/emoteListener.ts
@@ -16,6 +16,11 @@ export const emoteListener: Listener = {
         return;
       }
 
+      if (message.attachments.size > 0) {
+        await message.delete();
+        return;
+      }
+
       const newContent = message.content
         ?.replace(/:[^:\s]+:|<:[^:\s]+:[0-9]+>|<a:[^:\s]+:[0-9]+>/g, "")
         .replace(/\s/g, "");

--- a/src/modules/commands/config/viewSettings.ts
+++ b/src/modules/commands/config/viewSettings.ts
@@ -99,6 +99,11 @@ export const viewSettings = async (
       config.self_roles.length.toString(),
       true
     );
+    settingsEmbed.addField(
+      "Emote Only Channels",
+      config.emote_channels.length.toString(),
+      true
+    );
     settingsEmbed.setFooter(
       "Like the bot? Donate: https://donate.nhcarrigan.com"
     );

--- a/src/modules/settings/renderSetting.ts
+++ b/src/modules/settings/renderSetting.ts
@@ -54,6 +54,7 @@ export const renderSetting = (
         return `<@&${value}>`;
       case "automod_channels":
       case "no_automod_channels":
+      case "emote_channels":
         return value === "all" ? value : `<#${value}>`;
       case "level_roles":
         return `<@&${(value as LevelRole).role}> at level ${

--- a/src/modules/settings/setSetting.ts
+++ b/src/modules/settings/setSetting.ts
@@ -49,6 +49,7 @@ export const setSetting = async (
       case "self_roles":
       case "automod_roles":
       case "level_ignore":
+      case "emote_channels":
         if (server[key].includes(parsedValue)) {
           const index = server[key].indexOf(parsedValue);
           server[key].splice(index, 1);

--- a/src/modules/settings/validateSetting.ts
+++ b/src/modules/settings/validateSetting.ts
@@ -67,6 +67,7 @@ export const validateSetting = async (
         );
       case "automod_channels":
       case "no_automod_channels":
+      case "emote_channels":
         return (
           !!guild.channels.cache.find(
             (el) => el.type === "GUILD_TEXT" && el.id === `${parsedValue}`


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

This PR adds a new config allowing servers to set a channel to be emote only. Messages containing anything other than emotes will be deleted from those channels.

<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [X] My contribution DOES require a documentation update.
