### PR TITLE
fix: xpmodify logic

### DIFF
--- a/src/modules/commands/subcommands/manage/handleXpModify.ts
+++ b/src/modules/commands/subcommands/manage/handleXpModify.ts
@@ -84,21 +84,17 @@ export const handleXpModify: CommandHandler = async (
         cooldown: 0,
       }));
 
-    if (user.level >= 100) {
-      await interaction.editReply({
-        content: "That user has maxed out... over 9000!!!",
-      });
-      return;
-    }
-
     if (action === "add") {
-      if (user.points + amount >= levelScale[user.level + 1]) {
+      if (user.level >= 100) {
         await interaction.editReply({
-          content: "Can't increase XP beyond level cap.",
+          content: "That user has maxed out... over 9000!!!",
         });
         return;
       }
       user.points += amount;
+      while (user.points > levelScale[user.level + 1]) {
+        user.level++;
+      }
     } else {
       if (user.points - amount <= 0) {
         await interaction.editReply({
@@ -107,7 +103,11 @@ export const handleXpModify: CommandHandler = async (
         return;
       }
       user.points -= amount;
+      while (user.points <= levelScale[user.level]) {
+        user.level--;
+      }
     }
+
     user.userTag = target?.tag;
     user.avatar = target?.displayAvatarURL();
 

--- a/src/modules/commands/subcommands/manage/handleXpModify.ts
+++ b/src/modules/commands/subcommands/manage/handleXpModify.ts
@@ -117,8 +117,8 @@ export const handleXpModify: CommandHandler = async (
       }
     }
 
-    user.userTag = target?.tag;
-    user.avatar = target?.displayAvatarURL();
+    user.userTag = target.tag;
+    user.avatar = target.displayAvatarURL();
 
     await user.save();
 

--- a/src/modules/commands/subcommands/manage/handleXpModify.ts
+++ b/src/modules/commands/subcommands/manage/handleXpModify.ts
@@ -49,14 +49,14 @@ export const handleXpModify: CommandHandler = async (
       return;
     }
 
-    if (target?.id === member.user.id) {
+    if (target.id === member.user.id) {
       await interaction.editReply({
         content: getRandomValue(Becca.responses.noSelfXP),
       });
       return;
     }
 
-    if (target?.bot) {
+    if (target.bot) {
       await interaction.editReply({
         content: getRandomValue(Becca.responses.noBotXP),
       });
@@ -71,7 +71,7 @@ export const handleXpModify: CommandHandler = async (
     }
 
     const user =
-      (await LevelModel.findOne({ serverID: guild.id, userID: target?.id })) ||
+      (await LevelModel.findOne({ serverID: guild.id, userID: target.id })) ||
       (await LevelModel.create({
         serverID: guild.id,
         serverName: guild.name,
@@ -117,11 +117,11 @@ export const handleXpModify: CommandHandler = async (
     xpmodifyEmbed.setTitle("XP Modified");
     if (action === "add") {
       xpmodifyEmbed.setDescription(
-        `<@!${member?.user?.id}> has granted ${amount} XP to <@!${target?.id}>!`
+        `<@!${member.user.id}> has granted ${amount} XP to <@!${target.id}>!`
       );
     } else {
       xpmodifyEmbed.setDescription(
-        `<@!${member?.user?.id}> has taken away ${amount} XP from <@!${target.id}>!`
+        `<@!${member.user.id}> has taken away ${amount} XP from <@!${target.id}>!`
       );
     }
     xpmodifyEmbed.setColor(Becca.colours.default);


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

- Allows the moderator to assign enough XP that increases/decreases the user's level, and adjusts the level accordingly.
- Adds/removes level roles in response to the user's new level.
- Cleans up the optional chaining.

<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [X] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
