### PR TITLE
fix: limit leaderboard API to 100

### DIFF
--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -105,7 +105,11 @@ export const createServer = async (Becca: BeccaLyria): Promise<boolean> => {
       const data = await LevelModel.find(
         { serverID: req.params.serverId },
         { _id: 0, __v: 0 }
-      );
+      )
+        .sort({ points: -1 })
+        .limit(100)
+        .lean()
+        .exec();
 
       if (!data) {
         res.status(404).send("IDK what to put here yet.");


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

Restricts the API endpoint for server leaderboards to the first 100 documents. This will limit the DDoS attack vector and ensure the database doesn't get locked up when viewing large servers.

<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [X] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
