### PR TITLE
fix: no achivements when no habitica user found

### DIFF
--- a/src/modules/commands/subcommands/games/handleHabitica.ts
+++ b/src/modules/commands/subcommands/games/handleHabitica.ts
@@ -17,15 +17,17 @@ export const handleHabitica: CommandHandler = async (Becca, interaction) => {
       "x-api-user": "285a3335-33b9-473f-8d80-085c04f207bc",
       "x-api-key": Becca.configs.habiticaKey,
     };
+    const habiticaEmbeds = [];
+    habiticaEmbeds[0] = await generateHabiticaUser(Becca, id, headers);
+    if (habiticaEmbeds[0].title !== "User not found!") {
+      habiticaEmbeds[1] = await generateHabiticaAchievements(
+        Becca,
+        id,
+        headers
+      );
+    }
 
-    const userEmbed = await generateHabiticaUser(Becca, id, headers);
-    const achievementEmbed = await generateHabiticaAchievements(
-      Becca,
-      id,
-      headers
-    );
-
-    await interaction.editReply({ embeds: [userEmbed, achievementEmbed] });
+    await interaction.editReply({ embeds: habiticaEmbeds });
   } catch (err) {
     const errorId = await beccaErrorHandler(
       Becca,


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

<!-- A brief description of what your pull request does. -->
This PR fixes the Achievements embed shown for `/games habitica` command, even when there as no user found.

| Before | After |
| :-: | :-: |
| ![Image from before. Both user not found and no achievements embed](https://user-images.githubusercontent.com/91655303/139568443-f5470c18-7c15-4137-bef0-7e5ccc64b013.png) | ![image after PR. There is no embed for achievements if there is no user found](https://user-images.githubusercontent.com/62864373/146737221-10676f6f-a9eb-4b89-b19b-7f1231d6999f.png) |

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #957 

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
