### PR TITLE
feat: ban appeal link config

### DIFF
--- a/src/config/commands/settingsChoices.ts
+++ b/src/config/commands/settingsChoices.ts
@@ -21,6 +21,7 @@ export const configChoices: [string, Settings][] = [
   ["Custom Leave Message", "leave_message"],
   ["Report Channel", "report_channel"],
   ["No Levelling Channels", "level_ignore"],
+  ["Ban Appeal Link", "appeal_link"],
   ["Sass Mode", "sass_mode"],
   ["Emote-Only Channels", "emote_channels"],
 ];

--- a/src/config/database/defaultServer.ts
+++ b/src/config/database/defaultServer.ts
@@ -40,4 +40,5 @@ export const defaultServer = {
   profanity_message:
     "{@username}, your message appears to have been inappropriate. I removed it.",
   emote_channels: [] as string[],
+  appeal_link: "",
 };

--- a/src/database/models/ServerConfigModel.ts
+++ b/src/database/models/ServerConfigModel.ts
@@ -26,6 +26,7 @@ export const ServerConfigSchema = new Schema({
   sass_mode: String,
   triggers: Array,
   emote_channels: Array,
+  appeal_link: String,
   // automod
   automod_channels: [String],
   no_automod_channels: [String],

--- a/src/interfaces/database/ServerConfig.ts
+++ b/src/interfaces/database/ServerConfig.ts
@@ -36,6 +36,7 @@ export interface ServerConfig extends Document {
   profanity: string;
   profanity_message: string;
   emote_channels: string[];
+  appeal_link: string;
 }
 
 export const testServerConfig: Omit<ServerConfig, keyof Document> = {
@@ -71,4 +72,5 @@ export const testServerConfig: Omit<ServerConfig, keyof Document> = {
   profanity: "",
   profanity_message: "",
   emote_channels: [],
+  appeal_link: "",
 };

--- a/src/interfaces/settings/Settings.ts
+++ b/src/interfaces/settings/Settings.ts
@@ -31,4 +31,5 @@ export type Settings =
   | "links"
   | "profanity"
   | "profanity_message"
-  | "emote_channels";
+  | "emote_channels"
+  | "appeal_link";

--- a/src/modules/commands/config/viewSettings.ts
+++ b/src/modules/commands/config/viewSettings.ts
@@ -99,7 +99,11 @@ export const viewSettings = async (
       config.emote_channels.length.toString(),
       true
     );
-    settingsEmbed.addField("Ban Appeal Link", config.appeal_link, true);
+    settingsEmbed.addField(
+      "Ban Appeal Link",
+      config.appeal_link || "not set",
+      true
+    );
     settingsEmbed.setFooter(
       "Like the bot? Donate: https://donate.nhcarrigan.com",
       "https://cdn.nhcarrigan.com/profile-transparent.png"

--- a/src/modules/commands/config/viewSettings.ts
+++ b/src/modules/commands/config/viewSettings.ts
@@ -99,6 +99,7 @@ export const viewSettings = async (
       config.emote_channels.length.toString(),
       true
     );
+    settingsEmbed.addField("Ban Appeal Link", config.appeal_link, true);
     settingsEmbed.setFooter(
       "Like the bot? Donate: https://donate.nhcarrigan.com",
       "https://cdn.nhcarrigan.com/profile-transparent.png"

--- a/src/modules/commands/subcommands/moderation/handleBan.ts
+++ b/src/modules/commands/subcommands/moderation/handleBan.ts
@@ -14,7 +14,7 @@ import { updateHistory } from "../../moderation/updateHistory";
  * Bans the `target` user for the provided `reason`, assuming the caller has permissions.
  * Also deletes the `target`'s messages from the last 24 hours.
  */
-export const handleBan: CommandHandler = async (Becca, interaction) => {
+export const handleBan: CommandHandler = async (Becca, interaction, config) => {
   try {
     const { guild, member } = interaction;
     const target = interaction.options.getUser("target", true);
@@ -62,9 +62,9 @@ export const handleBan: CommandHandler = async (Becca, interaction) => {
 
     const sentNotice = await sendModerationDm(
       Becca,
+      config,
       "ban",
       target,
-      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleBan.ts
+++ b/src/modules/commands/subcommands/moderation/handleBan.ts
@@ -64,7 +64,7 @@ export const handleBan: CommandHandler = async (Becca, interaction) => {
       Becca,
       "ban",
       target,
-      guild.name,
+      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleKick.ts
+++ b/src/modules/commands/subcommands/moderation/handleKick.ts
@@ -14,7 +14,11 @@ import { updateHistory } from "../../moderation/updateHistory";
  * Provided the caller has permission, kicks the `target` user from the guild
  * for the given `reason`.
  */
-export const handleKick: CommandHandler = async (Becca, interaction, config) => {
+export const handleKick: CommandHandler = async (
+  Becca,
+  interaction,
+  config
+) => {
   try {
     const { guild, member } = interaction;
     const target = interaction.options.getUser("target", true);

--- a/src/modules/commands/subcommands/moderation/handleKick.ts
+++ b/src/modules/commands/subcommands/moderation/handleKick.ts
@@ -14,7 +14,7 @@ import { updateHistory } from "../../moderation/updateHistory";
  * Provided the caller has permission, kicks the `target` user from the guild
  * for the given `reason`.
  */
-export const handleKick: CommandHandler = async (Becca, interaction) => {
+export const handleKick: CommandHandler = async (Becca, interaction, config) => {
   try {
     const { guild, member } = interaction;
     const target = interaction.options.getUser("target", true);
@@ -62,9 +62,9 @@ export const handleKick: CommandHandler = async (Becca, interaction) => {
 
     const sentNotice = await sendModerationDm(
       Becca,
+      config,
       "kick",
       target,
-      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleKick.ts
+++ b/src/modules/commands/subcommands/moderation/handleKick.ts
@@ -64,7 +64,7 @@ export const handleKick: CommandHandler = async (Becca, interaction) => {
       Becca,
       "kick",
       target,
-      guild.name,
+      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleMute.ts
+++ b/src/modules/commands/subcommands/moderation/handleMute.ts
@@ -81,7 +81,7 @@ export const handleMute: CommandHandler = async (
       Becca,
       "mute",
       target,
-      guild.name,
+      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleMute.ts
+++ b/src/modules/commands/subcommands/moderation/handleMute.ts
@@ -79,9 +79,9 @@ export const handleMute: CommandHandler = async (
 
     const sentNotice = await sendModerationDm(
       Becca,
+      config,
       "mute",
       target,
-      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleUnmute.ts
+++ b/src/modules/commands/subcommands/moderation/handleUnmute.ts
@@ -66,7 +66,7 @@ export const handleUnmute: CommandHandler = async (
       Becca,
       "unmute",
       target,
-      guild.name,
+      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleUnmute.ts
+++ b/src/modules/commands/subcommands/moderation/handleUnmute.ts
@@ -64,9 +64,9 @@ export const handleUnmute: CommandHandler = async (
 
     const sentNotice = await sendModerationDm(
       Becca,
+      config,
       "unmute",
       target,
-      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleWarn.ts
+++ b/src/modules/commands/subcommands/moderation/handleWarn.ts
@@ -13,7 +13,11 @@ import { updateHistory } from "../../moderation/updateHistory";
  * Issues a warning to the `target` user, and adds it to the server's warning count.
  * Logs the `reason`.
  */
-export const handleWarn: CommandHandler = async (Becca, interaction, config) => {
+export const handleWarn: CommandHandler = async (
+  Becca,
+  interaction,
+  config
+) => {
   try {
     const { guild, member } = interaction;
     if (!guild) {

--- a/src/modules/commands/subcommands/moderation/handleWarn.ts
+++ b/src/modules/commands/subcommands/moderation/handleWarn.ts
@@ -55,7 +55,7 @@ export const handleWarn: CommandHandler = async (Becca, interaction) => {
       Becca,
       "warn",
       target,
-      guild.name,
+      guild,
       reason
     );
 

--- a/src/modules/commands/subcommands/moderation/handleWarn.ts
+++ b/src/modules/commands/subcommands/moderation/handleWarn.ts
@@ -13,7 +13,7 @@ import { updateHistory } from "../../moderation/updateHistory";
  * Issues a warning to the `target` user, and adds it to the server's warning count.
  * Logs the `reason`.
  */
-export const handleWarn: CommandHandler = async (Becca, interaction) => {
+export const handleWarn: CommandHandler = async (Becca, interaction, config) => {
   try {
     const { guild, member } = interaction;
     if (!guild) {
@@ -53,9 +53,9 @@ export const handleWarn: CommandHandler = async (Becca, interaction) => {
 
     const sentNotice = await sendModerationDm(
       Becca,
+      config,
       "warn",
       target,
-      guild,
       reason
     );
 

--- a/src/modules/settings/renderSetting.ts
+++ b/src/modules/settings/renderSetting.ts
@@ -31,6 +31,7 @@ export const renderSetting = (
       case "links":
       case "profanity":
       case "profanity_message":
+      case "appeal_link":
         return value as string;
       case "welcome_channel":
       case "depart_channel":
@@ -53,8 +54,6 @@ export const renderSetting = (
         return `<@&${value}>`;
       case "automod_channels":
       case "no_automod_channels":
-      case "appeal_link":
-        return value as string;
       case "emote_channels":
         return value === "all" ? value : `<#${value}>`;
       case "level_roles":

--- a/src/modules/settings/renderSetting.ts
+++ b/src/modules/settings/renderSetting.ts
@@ -53,6 +53,8 @@ export const renderSetting = (
         return `<@&${value}>`;
       case "automod_channels":
       case "no_automod_channels":
+      case "appeal_link":
+        return value as string;
       case "emote_channels":
         return value === "all" ? value : `<#${value}>`;
       case "level_roles":

--- a/src/modules/settings/setSetting.ts
+++ b/src/modules/settings/setSetting.ts
@@ -92,6 +92,7 @@ export const setSetting = async (
       case "links":
       case "profanity":
       case "profanity_message":
+      case "appeal_link":
         server[key] = value;
         break;
       case "welcome_channel":
@@ -106,9 +107,6 @@ export const setSetting = async (
       case "join_role":
       case "report_channel":
         server[key] = value.replace(/\D/g, "");
-        break;
-      case "appeal_link":
-        server[key] = value;
         break;
       default:
         beccaLogHandler.log("error", "the setSettings logic broke horribly.");

--- a/src/modules/settings/setSetting.ts
+++ b/src/modules/settings/setSetting.ts
@@ -107,6 +107,9 @@ export const setSetting = async (
       case "report_channel":
         server[key] = value.replace(/\D/g, "");
         break;
+      case "appeal_link":
+        server[key] = value;
+        break;
       default:
         beccaLogHandler.log("error", "the setSettings logic broke horribly.");
     }

--- a/src/modules/settings/validateSetting.ts
+++ b/src/modules/settings/validateSetting.ts
@@ -93,6 +93,7 @@ export const validateSetting = async (
           !!(await guild.roles.fetch(role.replace(/\D/g, "") as `${bigint}`))
         );
       case "allowed_links":
+      case "appeal_link":
       case "custom_welcome":
       case "link_message":
       case "leave_message":

--- a/src/utils/sendModerationDm.ts
+++ b/src/utils/sendModerationDm.ts
@@ -1,8 +1,8 @@
-import { MessageEmbed, User, Guild } from "discord.js";
+import { MessageEmbed, User } from "discord.js";
 
-import ServerModel from "../database/models/ServerConfigModel";
 import { BeccaLyria } from "../interfaces/BeccaLyria";
 import { ModerationActions } from "../interfaces/commands/moderation/ModerationActions";
+import { ServerConfig } from "../interfaces/database/ServerConfig";
 
 import { beccaErrorHandler } from "./beccaErrorHandler";
 import { customSubstring } from "./customSubstring";
@@ -11,17 +11,17 @@ import { customSubstring } from "./customSubstring";
  * Generates a moderation embed notice and sends it to the user.
  *
  * @param {BeccaLyria} Becca Becca's Discord instance.
+ * @param {ServerConfig} config The settings for the server where this function was triggered.
  * @param {ModerationActions} action The moderation action taken.
  * @param {User} user The Discord user being moderated.
- * @param {string} guild The guild the moderation occurred in.
  * @param {string} reason The reason for the moderation action.
  * @returns {boolean} True if the message was sent, false otherwise.
  */
 export const sendModerationDm = async (
   Becca: BeccaLyria,
+  config: ServerConfig,
   action: ModerationActions,
   user: User,
-  guild: Guild,
   reason: string
 ): Promise<boolean> => {
   try {
@@ -29,20 +29,15 @@ export const sendModerationDm = async (
     embed.setTitle(`${action} Notification!`);
     embed.setDescription(
       `You have received a ${action} in ${
-        guild.name
+        config.serverName
       } for: \n\n${customSubstring(reason, 2000)}`
     );
 
-    if (action === "ban") {
-      const serverID = guild.id;
-      const server = (await ServerModel.findOne({ serverID })) || null;
-
-      if (server && server.appeal_link.length) {
-        embed.addField(
-          "You can appeal your ban using this link: ",
-          server.appeal_link
-        );
-      }
+    if (action === "ban" && config.appeal_link.length) {
+      embed.addField(
+        "You can appeal your ban using this link: ",
+        config.appeal_link
+      );
     }
 
     const sent = await user
@@ -51,7 +46,7 @@ export const sendModerationDm = async (
       .catch(() => false);
     return sent;
   } catch (err) {
-    await beccaErrorHandler(Becca, "send moderation dm", err, guild.name);
+    await beccaErrorHandler(Becca, "send moderation dm", err, config.serverName);
     return false;
   }
 };

--- a/src/utils/sendModerationDm.ts
+++ b/src/utils/sendModerationDm.ts
@@ -46,7 +46,12 @@ export const sendModerationDm = async (
       .catch(() => false);
     return sent;
   } catch (err) {
-    await beccaErrorHandler(Becca, "send moderation dm", err, config.serverName);
+    await beccaErrorHandler(
+      Becca,
+      "send moderation dm",
+      err,
+      config.serverName
+    );
     return false;
   }
 };

--- a/src/utils/sendModerationDm.ts
+++ b/src/utils/sendModerationDm.ts
@@ -37,13 +37,11 @@ export const sendModerationDm = async (
       const serverID = guild.id;
       const server = (await ServerModel.findOne({ serverID })) || null;
 
-      if (server) {
-        if (server.appeal_link.length > 0) {
-          embed.addField(
-            "You can appeal your ban using this link: ",
-            server.appeal_link
-          );
-        }
+      if (server && server.appeal_link.length) {
+        embed.addField(
+          "You can appeal your ban using this link: ",
+          server.appeal_link
+        );
       }
     }
 


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

<!-- A brief description of what your pull request does. -->
This PR adds a config setting for ban appeal link, where a server can provide a link to a Google Form (or other option) for appealing a ban. Then, when a user is banned, if this config is set, Becca includes the value in the DM sent to the user.

## Results
- Appeal link in the DM sent on ban
![Screenshot 2022-01-10 at 1 57 41 AM](https://user-images.githubusercontent.com/62864373/148699802-e7b2f324-ed1e-48ca-933b-328ec1b2236a.png)
- Setting the config link
![Screenshot 2022-01-10 at 2 06 34 AM](https://user-images.githubusercontent.com/62864373/148699838-1a47a1b4-97f8-4bdb-9623-878b6055515d.png)
- Config View Embed
![Screenshot 2022-01-10 at 2 07 20 AM](https://user-images.githubusercontent.com/62864373/148699858-a3cd4082-d062-442a-95ec-06a4315d2051.png)


## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #1071

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [x] My contribution DOES require a documentation update.
