### PR TITLE
fix: update link in adventure command

### DIFF
--- a/src/modules/commands/subcommands/becca/handleAdventure.ts
+++ b/src/modules/commands/subcommands/becca/handleAdventure.ts
@@ -36,7 +36,7 @@ export const handleAdventure: CommandHandler = async (Becca, interaction) => {
       .setLabel("View More Adventures!")
       .setEmoji("<:BeccaWork:883854701416833024>")
       .setStyle("LINK")
-      .setURL("https://www.beccalyria.com/games");
+      .setURL("https://beccalyria.com/adventures");
 
     const row = new MessageActionRow().addComponents([artButton]);
 


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

As mentioned, the URL in .setUrl of handleAdventure.ts has been changed.
![image](https://user-images.githubusercontent.com/47622667/148721960-349822db-0d11-4f19-a0e1-2dc7ae12103d.png)

<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #1097

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

My contribution does NOT require a documentation update.
