### PR TITLE
feat: timeout invalid-link prompt

### DIFF
--- a/src/listeners/automod/automodLinks.ts
+++ b/src/listeners/automod/automodLinks.ts
@@ -76,9 +76,10 @@ export const automodLinks: ListenerHandler = async (Becca, message, config) => {
       );
       const warning = await message.channel.send({ embeds: [linkEmbed] });
 
+      setTimeout(async () => await warning.delete(), 300000);
+
       const dmEmbed = new MessageEmbed();
       dmEmbed.setTitle("Your message has been deleted...");
-      dmEmbed.setURL(warning.url);
       dmEmbed.setDescription(
         "Here's the contents of the deleted message: \n```\n" +
           customSubstring(message.content, 2000) +


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

<!-- A brief description of what your pull request does. -->
Modifies the automodLinks Listener, and adds a 5 minute timeout to the "Invalid-link" prompt.

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #1088 

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
