### PR TITLE
feat: add reaction role system

### DIFF
--- a/src/commands/reactionRole.ts
+++ b/src/commands/reactionRole.ts
@@ -1,0 +1,126 @@
+import {
+  SlashCommandBuilder,
+  SlashCommandSubcommandBuilder,
+} from "@discordjs/builders";
+
+import { Command } from "../interfaces/commands/Command";
+import { errorEmbedGenerator } from "../modules/commands/errorEmbedGenerator";
+import { handleReactionAdd } from "../modules/commands/subcommands/reactionrole/handleReactionAdd";
+import { handleReactionList } from "../modules/commands/subcommands/reactionrole/handleReactionList";
+import { handleReactionRemove } from "../modules/commands/subcommands/reactionrole/handleReactionRemove";
+import { beccaErrorHandler } from "../utils/beccaErrorHandler";
+import { getRandomValue } from "../utils/getRandomValue";
+
+export const reactionRole: Command = {
+  data: new SlashCommandBuilder()
+    .setName("reactionrole")
+    .setDescription("Commands for managing reaction roles.")
+    .addSubcommand(
+      new SlashCommandSubcommandBuilder()
+        .setName("add")
+        .setDescription("Add a reaction role to a message.")
+        .addStringOption((option) =>
+          option
+            .setName("message")
+            .setDescription("The message LINK to add the reaction role to.")
+            .setRequired(true)
+        )
+        .addStringOption((option) =>
+          option
+            .setName("emoji")
+            .setDescription("The emoji to react with.")
+            .setRequired(true)
+        )
+        .addRoleOption((option) =>
+          option
+            .setName("role")
+            .setDescription("The role to add or remove.")
+            .setRequired(true)
+        )
+    )
+    .addSubcommand(
+      new SlashCommandSubcommandBuilder()
+        .setName("remove")
+        .setDescription("Remove a reaction role from a message.")
+        .addStringOption((option) =>
+          option
+            .setName("message")
+            .setDescription(
+              "The message LINK to remove the reaction role from."
+            )
+            .setRequired(true)
+        )
+        .addStringOption((option) =>
+          option
+            .setName("emoji")
+            .setDescription("The emoji to react with.")
+            .setRequired(true)
+        )
+    )
+    .addSubcommand(
+      new SlashCommandSubcommandBuilder()
+        .setName("list")
+        .setDescription("List all reaction roles on a message.")
+        .addStringOption((option) =>
+          option
+            .setName("message")
+            .setDescription("The message LINK to list the reaction roles on.")
+            .setRequired(true)
+        )
+    ),
+  run: async (Becca, interaction, config) => {
+    try {
+      await interaction.deferReply();
+      const { guild, member } = interaction;
+
+      if (!guild || !member) {
+        await interaction.editReply({
+          content: getRandomValue(Becca.responses.missingGuild),
+        });
+        return;
+      }
+
+      if (
+        (typeof member.permissions === "string" ||
+          !member.permissions.has("MANAGE_GUILD")) &&
+        member.user.id !== Becca.configs.ownerId
+      ) {
+        await interaction.editReply({
+          content: getRandomValue(Becca.responses.noPermission),
+        });
+        return;
+      }
+
+      const action = interaction.options.getSubcommand();
+      switch (action) {
+        case "add":
+          await handleReactionAdd(Becca, interaction, config);
+          break;
+        case "remove":
+          await handleReactionRemove(Becca, interaction, config);
+          break;
+        case "list":
+          await handleReactionList(Becca, interaction, config);
+          break;
+        default:
+          await interaction.editReply({
+            content: getRandomValue(Becca.responses.invalidCommand),
+          });
+          break;
+      }
+      Becca.pm2.metrics.commands.mark();
+    } catch (err) {
+      const errorId = await beccaErrorHandler(
+        Becca,
+        "reaction role command group",
+        err,
+        interaction.guild?.name,
+        undefined,
+        interaction
+      );
+      await interaction.editReply({
+        embeds: [errorEmbedGenerator(Becca, "reaction role group", errorId)],
+      });
+    }
+  },
+};

--- a/src/database/models/ReactionRoleModel.ts
+++ b/src/database/models/ReactionRoleModel.ts
@@ -1,0 +1,14 @@
+import { model, Schema } from "mongoose";
+
+import { ReactionRole } from "../../interfaces/database/ReactionRole";
+
+export const ReactionRoleSchema = new Schema({
+  serverId: String,
+  serverName: String,
+  channelId: String,
+  messageId: String,
+  emoji: String,
+  roleId: String,
+});
+
+export default model<ReactionRole>("ReactionRole", ReactionRoleSchema);

--- a/src/events/clientEvents/ready.ts
+++ b/src/events/clientEvents/ready.ts
@@ -12,7 +12,7 @@ import { cacheReactionRoles } from "../../utils/cacheReactionRoles";
  * @param {BeccaLyria} Becca Becca's Client instance.
  */
 export const ready = async (Becca: BeccaLyria): Promise<void> => {
-  console.log("Fetching reaction role data...");
+  beccaLogHandler.log("debug", "Fetching reaction role data...");
   await cacheReactionRoles(Becca);
   const readyEmbed = new MessageEmbed();
   readyEmbed.setTitle("Becca is online");

--- a/src/events/clientEvents/ready.ts
+++ b/src/events/clientEvents/ready.ts
@@ -3,6 +3,7 @@ import { MessageEmbed } from "discord.js";
 import { BeccaLyria } from "../../interfaces/BeccaLyria";
 import { getCounts } from "../../modules/becca/getCounts";
 import { beccaLogHandler } from "../../utils/beccaLogHandler";
+import { cacheReactionRoles } from "../../utils/cacheReactionRoles";
 
 /**
  * Sends a notification to the debug hook when Becca has connected to
@@ -11,6 +12,8 @@ import { beccaLogHandler } from "../../utils/beccaLogHandler";
  * @param {BeccaLyria} Becca Becca's Client instance.
  */
 export const ready = async (Becca: BeccaLyria): Promise<void> => {
+  console.log("Fetching reaction role data...");
+  await cacheReactionRoles(Becca);
   const readyEmbed = new MessageEmbed();
   readyEmbed.setTitle("Becca is online");
   readyEmbed.setDescription(

--- a/src/events/handleEvents.ts
+++ b/src/events/handleEvents.ts
@@ -11,6 +11,8 @@ import { memberUpdate } from "./memberEvents/memberUpdate";
 import { messageCreate } from "./messageEvents/messageCreate";
 import { messageDelete } from "./messageEvents/messageDelete";
 import { messageUpdate } from "./messageEvents/messageUpdate";
+import { reactionAdd } from "./reactionEvents.ts/reactionAdd";
+import { reactionRemove } from "./reactionEvents.ts/reactionRemove";
 import { shardError } from "./shardEvents/shardError";
 import { shardReady } from "./shardEvents/shardReady";
 import { threadCreate } from "./threadEvents/threadCreate";
@@ -78,6 +80,13 @@ export const handleEvents = (Becca: BeccaLyria): void => {
   });
   Becca.on("threadDelete", async (thread) => {
     await threadDelete(Becca, thread);
+  });
+
+  Becca.on("messageReactionAdd", async (reaction, user) => {
+    await reactionAdd(Becca, reaction, user);
+  });
+  Becca.on("messageReactionRemove", async (reaction, user) => {
+    await reactionRemove(Becca, reaction, user);
   });
 
   Becca.on("interactionCreate", async (interaction) => {

--- a/src/events/reactionEvents.ts/reactionAdd.ts
+++ b/src/events/reactionEvents.ts/reactionAdd.ts
@@ -1,0 +1,63 @@
+import {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from "discord.js";
+
+import ReactionRoleModel from "../../database/models/ReactionRoleModel";
+import { BeccaLyria } from "../../interfaces/BeccaLyria";
+import { beccaErrorHandler } from "../../utils/beccaErrorHandler";
+
+/**
+ * Handles the messageReactionAdd event. Checks for a related reaction role and applies it.
+ *
+ * @param {BeccaLyria} Becca Becca's Discord instance.
+ * @param {MessageReaction | PartialMessageReaction} reaction The reaction payload from Discord.
+ * @param {User | PartialUser} user The user that added the reaction.
+ */
+export const reactionAdd = async (
+  Becca: BeccaLyria,
+  reaction: MessageReaction | PartialMessageReaction,
+  user: User | PartialUser
+) => {
+  try {
+    if (user.bot || !reaction.message.guildId || !reaction.message.channelId) {
+      return;
+    }
+
+    const { id: messageId, guildId: serverId, channelId } = reaction.message;
+
+    const emojiValue = reaction.emoji.id || reaction.emoji.name;
+
+    if (!emojiValue) {
+      return;
+    }
+
+    const hasReactionRole = await ReactionRoleModel.findOne({
+      serverId,
+      messageId,
+      channelId,
+      emoji: emojiValue,
+    });
+
+    if (!hasReactionRole) {
+      return;
+    }
+
+    const member =
+      reaction.message.guild?.members.cache.find((el) => el.id === user.id) ||
+      (await reaction.message.guild?.members.fetch(user.id));
+    const role =
+      reaction.message.guild?.roles.cache.find(
+        (el) => el.id === hasReactionRole.roleId
+      ) || (await reaction.message.guild?.roles.fetch(hasReactionRole.roleId));
+    if (!member || !role) {
+      return;
+    }
+
+    await member.roles.add(role);
+  } catch (err) {
+    await beccaErrorHandler(Becca, "reaction remove event", err);
+  }
+};

--- a/src/events/reactionEvents.ts/reactionRemove.ts
+++ b/src/events/reactionEvents.ts/reactionRemove.ts
@@ -1,0 +1,63 @@
+import {
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from "discord.js";
+
+import ReactionRoleModel from "../../database/models/ReactionRoleModel";
+import { BeccaLyria } from "../../interfaces/BeccaLyria";
+import { beccaErrorHandler } from "../../utils/beccaErrorHandler";
+
+/**
+ * Handles the messageReactionRemove event. Checks for a related reaction role and applies it.
+ *
+ * @param {BeccaLyria} Becca Becca's Discord instance.
+ * @param {MessageReaction | PartialMessageReaction} reaction The reaction payload from Discord.
+ * @param {User | PartialUser} user The user that removed the reaction.
+ */
+export const reactionRemove = async (
+  Becca: BeccaLyria,
+  reaction: MessageReaction | PartialMessageReaction,
+  user: User | PartialUser
+) => {
+  try {
+    if (user.bot || !reaction.message.guildId || !reaction.message.channelId) {
+      return;
+    }
+
+    const { id: messageId, guildId: serverId, channelId } = reaction.message;
+
+    const emojiValue = reaction.emoji.id || reaction.emoji.name;
+
+    if (!emojiValue) {
+      return;
+    }
+
+    const hasReactionRole = await ReactionRoleModel.findOne({
+      serverId,
+      messageId,
+      channelId,
+      emoji: emojiValue,
+    });
+
+    if (!hasReactionRole) {
+      return;
+    }
+
+    const member =
+      reaction.message.guild?.members.cache.find((el) => el.id === user.id) ||
+      (await reaction.message.guild?.members.fetch(user.id));
+    const role =
+      reaction.message.guild?.roles.cache.find(
+        (el) => el.id === hasReactionRole.roleId
+      ) || (await reaction.message.guild?.roles.fetch(hasReactionRole.roleId));
+    if (!member || !role) {
+      return;
+    }
+
+    await member.roles.remove(role);
+  } catch (err) {
+    await beccaErrorHandler(Becca, "reaction remove event", err);
+  }
+};

--- a/src/interfaces/database/ReactionRole.ts
+++ b/src/interfaces/database/ReactionRole.ts
@@ -1,0 +1,19 @@
+import { Document } from "mongoose";
+
+export interface ReactionRole extends Document {
+  serverId: string;
+  serverName: string;
+  channelId: string;
+  messageId: string;
+  emoji: string;
+  roleId: string;
+}
+
+export const testReactionRole: Omit<ReactionRole, keyof Document> = {
+  serverId: "123456789",
+  serverName: "Test Server",
+  channelId: "123456789",
+  messageId: "123456789",
+  emoji: "🎉",
+  roleId: "123456789",
+};

--- a/src/modules/commands/subcommands/reactionrole/handleReactionAdd.ts
+++ b/src/modules/commands/subcommands/reactionrole/handleReactionAdd.ts
@@ -1,0 +1,82 @@
+/* eslint-disable jsdoc/require-param */
+import { Guild, MessageEmbed, TextBasedChannel } from "discord.js";
+
+import ReactionRoleModel from "../../../../database/models/ReactionRoleModel";
+import { CommandHandler } from "../../../../interfaces/commands/CommandHandler";
+import { beccaErrorHandler } from "../../../../utils/beccaErrorHandler";
+import { errorEmbedGenerator } from "../../errorEmbedGenerator";
+
+/**
+ * Adds a reaction role to the provided message.
+ */
+export const handleReactionAdd: CommandHandler = async (Becca, interaction) => {
+  try {
+    const guild = interaction.guild as Guild;
+    const messageLink = interaction.options.getString("message", true);
+    const [messageId, channelId, serverId] = messageLink.split("/").reverse();
+    const targetChannel = guild.channels.cache.get(
+      channelId
+    ) as TextBasedChannel;
+    const targetMessage = await targetChannel?.messages.fetch(messageId);
+
+    if (!targetMessage) {
+      await interaction.editReply("That message does not exist.");
+      return;
+    }
+
+    const emoji = interaction.options.getString("emoji", true);
+
+    const reacted = await targetMessage
+      .react(emoji)
+      .then(() => true)
+      .catch(() => false);
+    if (!reacted) {
+      await interaction.editReply("That emoji does not appear to be valid...");
+      return;
+    }
+
+    const role = interaction.options.getRole("role", true);
+    const reactionRole =
+      (await ReactionRoleModel.findOne({
+        serverId,
+        channelId,
+        messageId,
+        emoji,
+      })) ||
+      (await ReactionRoleModel.create({
+        serverId,
+        channelId,
+        messageId,
+        emoji,
+        roleId: role.id,
+      }));
+
+    reactionRole.roleId = role.id;
+    await reactionRole.save();
+
+    const addEmbed = new MessageEmbed();
+    addEmbed.setTitle("Reaction Role Added");
+    addEmbed.setColor(Becca.colours.default);
+    addEmbed.setDescription(`${emoji} associated with <@&${role.id}>`);
+    addEmbed.addField("Message", messageLink);
+    addEmbed.setTimestamp();
+    addEmbed.setFooter(
+      "Like the bot? Donate: https://donate.nhcarrigan.com",
+      "https://cdn.nhcarrigan.com/profile-transparent.png"
+    );
+
+    await interaction.editReply({ embeds: [addEmbed] });
+  } catch (err) {
+    const errorId = await beccaErrorHandler(
+      Becca,
+      "handleReactionAdd command",
+      err,
+      interaction.guild?.name,
+      undefined,
+      interaction
+    );
+    await interaction.editReply({
+      embeds: [errorEmbedGenerator(Becca, "handleReactionAdd", errorId)],
+    });
+  }
+};

--- a/src/modules/commands/subcommands/reactionrole/handleReactionAdd.ts
+++ b/src/modules/commands/subcommands/reactionrole/handleReactionAdd.ts
@@ -28,10 +28,17 @@ export const handleReactionAdd: CommandHandler = async (Becca, interaction) => {
 
     const reacted = await targetMessage
       .react(emoji)
-      .then(() => true)
-      .catch(() => false);
+      .then((data) => data)
+      .catch(() => null);
     if (!reacted) {
       await interaction.editReply("That emoji does not appear to be valid...");
+      return;
+    }
+
+    const emojiValue = reacted.emoji.id || reacted.emoji.name;
+
+    if (!emojiValue) {
+      await interaction.editReply("I can't seem to parse that emoji...");
       return;
     }
 
@@ -41,13 +48,13 @@ export const handleReactionAdd: CommandHandler = async (Becca, interaction) => {
         serverId,
         channelId,
         messageId,
-        emoji,
+        emoji: emojiValue,
       })) ||
       (await ReactionRoleModel.create({
         serverId,
         channelId,
         messageId,
-        emoji,
+        emoji: emojiValue,
         roleId: role.id,
       }));
 
@@ -57,7 +64,7 @@ export const handleReactionAdd: CommandHandler = async (Becca, interaction) => {
     const addEmbed = new MessageEmbed();
     addEmbed.setTitle("Reaction Role Added");
     addEmbed.setColor(Becca.colours.default);
-    addEmbed.setDescription(`${emoji} associated with <@&${role.id}>`);
+    addEmbed.setDescription(`\`${emoji}\` associated with <@&${role.id}>`);
     addEmbed.addField("Message", messageLink);
     addEmbed.setTimestamp();
     addEmbed.setFooter(

--- a/src/modules/commands/subcommands/reactionrole/handleReactionList.ts
+++ b/src/modules/commands/subcommands/reactionrole/handleReactionList.ts
@@ -43,7 +43,7 @@ export const handleReactionList: CommandHandler = async (
     listEmbed.setTitle("Reaction Roles");
     listEmbed.setColor(Becca.colours.default);
     listEmbed.setDescription(
-      reactionRoles.map((el) => `${el.emoji}: <@&${el.roleId}>`).join("\n")
+      reactionRoles.map((el) => `\`${el.emoji}\`: <@&${el.roleId}>`).join("\n")
     );
     listEmbed.addField("Message", messageLink);
     listEmbed.setTimestamp();

--- a/src/modules/commands/subcommands/reactionrole/handleReactionList.ts
+++ b/src/modules/commands/subcommands/reactionrole/handleReactionList.ts
@@ -1,0 +1,69 @@
+/* eslint-disable jsdoc/require-param */
+import { Guild, MessageEmbed, TextBasedChannel } from "discord.js";
+
+import ReactionRoleModel from "../../../../database/models/ReactionRoleModel";
+import { CommandHandler } from "../../../../interfaces/commands/CommandHandler";
+import { beccaErrorHandler } from "../../../../utils/beccaErrorHandler";
+import { errorEmbedGenerator } from "../../errorEmbedGenerator";
+
+/**
+ * Generates an embed listing the reaction roles assigned to a provided message.
+ */
+export const handleReactionList: CommandHandler = async (
+  Becca,
+  interaction
+) => {
+  try {
+    const guild = interaction.guild as Guild;
+    const messageLink = interaction.options.getString("message", true);
+    const [messageId, channelId, serverId] = messageLink.split("/").reverse();
+
+    const targetChannel = guild.channels.cache.get(
+      channelId
+    ) as TextBasedChannel;
+    const targetMessage = await targetChannel?.messages.fetch(messageId);
+
+    if (!targetMessage) {
+      await interaction.editReply("That message does not exist.");
+      return;
+    }
+
+    const reactionRoles = await ReactionRoleModel.find({
+      messageId,
+      channelId,
+      serverId,
+    });
+
+    if (!reactionRoles.length) {
+      await interaction.editReply("That message has no reaction roles.");
+      return;
+    }
+
+    const listEmbed = new MessageEmbed();
+    listEmbed.setTitle("Reaction Roles");
+    listEmbed.setColor(Becca.colours.default);
+    listEmbed.setDescription(
+      reactionRoles.map((el) => `${el.emoji}: <@&${el.roleId}>`).join("\n")
+    );
+    listEmbed.addField("Message", messageLink);
+    listEmbed.setTimestamp();
+    listEmbed.setFooter(
+      "Like the bot? Donate: https://donate.nhcarrigan.com",
+      "https://cdn.nhcarrigan.com/profile-transparent.png"
+    );
+
+    await interaction.editReply({ embeds: [listEmbed] });
+  } catch (err) {
+    const errorId = await beccaErrorHandler(
+      Becca,
+      "handleReactionList command",
+      err,
+      interaction.guild?.name,
+      undefined,
+      interaction
+    );
+    await interaction.editReply({
+      embeds: [errorEmbedGenerator(Becca, "handleReactionList", errorId)],
+    });
+  }
+};

--- a/src/modules/commands/subcommands/reactionrole/handleReactionRemove.ts
+++ b/src/modules/commands/subcommands/reactionrole/handleReactionRemove.ts
@@ -1,0 +1,60 @@
+/* eslint-disable jsdoc/require-param */
+import { MessageEmbed } from "discord.js";
+
+import ReactionRoleModel from "../../../../database/models/ReactionRoleModel";
+import { CommandHandler } from "../../../../interfaces/commands/CommandHandler";
+import { beccaErrorHandler } from "../../../../utils/beccaErrorHandler";
+import { errorEmbedGenerator } from "../../errorEmbedGenerator";
+
+/**
+ * Removes a reaction role from a message.
+ */
+export const handleReactionRemove: CommandHandler = async (
+  Becca,
+  interaction
+) => {
+  try {
+    const messageLink = interaction.options.getString("message", true);
+    const [messageId, channelId, serverId] = messageLink.split("/").reverse();
+    const emoji = interaction.options.getString("emoji", true);
+    const reactionRole = await ReactionRoleModel.findOne({
+      serverId,
+      channelId,
+      messageId,
+      emoji,
+    });
+
+    if (!reactionRole) {
+      await interaction.editReply("That reaction role does not exist.");
+      return;
+    }
+    await reactionRole.delete();
+
+    const removeEmbed = new MessageEmbed();
+    removeEmbed.setTitle("Reaction Role Removed");
+    removeEmbed.setColor(Becca.colours.default);
+    removeEmbed.setDescription(
+      `${reactionRole.emoji} no longer associated with <@&${reactionRole.roleId}>`
+    );
+    removeEmbed.addField("Message", messageLink);
+    removeEmbed.setTimestamp();
+    removeEmbed.setFooter(
+      "Like the bot? Donate: https://donate.nhcarrigan.com",
+      "https://cdn.nhcarrigan.com/profile-transparent.png"
+    );
+
+    await interaction.editReply({ embeds: [removeEmbed] });
+  } catch (err) {
+    const errorId = await beccaErrorHandler(
+      Becca,
+      "handleReactionRemove command",
+      err,
+      interaction.guild?.name,
+      undefined,
+      interaction
+    );
+    await interaction.editReply({
+      embeds: [errorEmbedGenerator(Becca, "handleReactionRemove", errorId)],
+    });
+  }
+};

--- a/src/utils/cacheReactionRoles.ts
+++ b/src/utils/cacheReactionRoles.ts
@@ -4,6 +4,7 @@ import ReactionRoleModel from "../database/models/ReactionRoleModel";
 import { BeccaLyria } from "../interfaces/BeccaLyria";
 
 import { beccaErrorHandler } from "./beccaErrorHandler";
+import { beccaLogHandler } from "./beccaLogHandler";
 
 /**
  * Iterates through the reaction role data, fetching anything that isn't already cached.
@@ -34,7 +35,8 @@ export const cacheReactionRoles = async (Becca: BeccaLyria): Promise<void> => {
       if (!message) {
         continue;
       }
-      console.log(
+      beccaLogHandler.log(
+        "info",
         `Cached message ${message.id} in ${channel.name} of ${guild.name}`
       );
     }

--- a/src/utils/cacheReactionRoles.ts
+++ b/src/utils/cacheReactionRoles.ts
@@ -1,0 +1,44 @@
+import { TextChannel } from "discord.js";
+
+import ReactionRoleModel from "../database/models/ReactionRoleModel";
+import { BeccaLyria } from "../interfaces/BeccaLyria";
+
+import { beccaErrorHandler } from "./beccaErrorHandler";
+
+/**
+ * Iterates through the reaction role data, fetching anything that isn't already cached.
+ * Otherwise we don't seem to get the reaction event.
+ *
+ * @param {BeccaLyria} Becca Becca's Discord instance.
+ */
+export const cacheReactionRoles = async (Becca: BeccaLyria): Promise<void> => {
+  try {
+    const roleList = await ReactionRoleModel.find({});
+
+    for (const reactionRole of roleList) {
+      const guild =
+        Becca.guilds.cache.find((el) => el.id === reactionRole.serverId) ||
+        (await Becca.guilds.fetch(reactionRole.serverId));
+      if (!guild) {
+        continue;
+      }
+      const channel =
+        guild.channels.cache.find((el) => el.id === reactionRole.channelId) ||
+        (await guild.channels.fetch(reactionRole.channelId));
+      if (!channel) {
+        continue;
+      }
+      const message = await (channel as TextChannel).messages.fetch(
+        reactionRole.messageId
+      );
+      if (!message) {
+        continue;
+      }
+      console.log(
+        `Cached message ${message.id} in ${channel.name} of ${guild.name}`
+      );
+    }
+  } catch (err) {
+    await beccaErrorHandler(Becca, "reaction role caching", err);
+  }
+};

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -6,6 +6,7 @@ import CurrencyModel from "../src/database/models/CurrencyModel";
 import EmoteCountModel from "../src/database/models/EmoteCountModel";
 import HistoryModel from "../src/database/models/HistoryModel";
 import LevelModel from "../src/database/models/LevelModel";
+import ReactionRoleModel from "../src/database/models/ReactionRoleModel";
 import ServerConfigModel from "../src/database/models/ServerConfigModel";
 import StarModel from "../src/database/models/StarModel";
 import UsageModel from "../src/database/models/UsageModel";
@@ -16,6 +17,7 @@ import { testCurrency } from "../src/interfaces/database/Currency";
 import { testEmoteCount } from "../src/interfaces/database/EmoteCount";
 import { testHistory } from "../src/interfaces/database/History";
 import { testLevel } from "../src/interfaces/database/Level";
+import { testReactionRole } from "../src/interfaces/database/ReactionRole";
 import { testServerConfig } from "../src/interfaces/database/ServerConfig";
 import { testStar } from "../src/interfaces/database/Star";
 import { testUsage } from "../src/interfaces/database/Usage";
@@ -75,6 +77,18 @@ suite("Schema Validation", () => {
     for (const key in testLevel) {
       test(`${key} should be in the Level schema`, () => {
         assert(key in testModel, `Missing ${key} from the Level schema.`);
+      });
+    }
+  });
+
+  suite("Reaction Role Model", () => {
+    const testModel = new ReactionRoleModel();
+    for (const key in testReactionRole) {
+      test(`${key} should be in the Reaction Role schema`, () => {
+        assert(
+          key in testModel,
+          `Missing ${key} from the Reaction Role schema.`
+        );
       });
     }
   });


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

By popular demand...

- Adds reaction role commands to manage the system
- Adds database schema to store reaction roles
- Adds step to cache messages on boot
- Adds listeners to the reaction events to assign/remove roles accordingly
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [X] My contribution DOES require a documentation update.
