### PR TITLE
fix: don't fetch messages more than once

### DIFF
--- a/src/utils/cacheReactionRoles.ts
+++ b/src/utils/cacheReactionRoles.ts
@@ -15,23 +15,27 @@ import { beccaLogHandler } from "./beccaLogHandler";
 export const cacheReactionRoles = async (Becca: BeccaLyria): Promise<void> => {
   try {
     const roleList = await ReactionRoleModel.find({});
+    const cacheMap = new Set();
 
     for (const reactionRole of roleList) {
+      const { messageId, channelId, serverId } = reactionRole;
+      if (cacheMap.has(`${serverId}/${channelId}/${messageId}`)) {
+        continue;
+      }
       const guild =
-        Becca.guilds.cache.find((el) => el.id === reactionRole.serverId) ||
-        (await Becca.guilds.fetch(reactionRole.serverId));
+        Becca.guilds.cache.find((el) => el.id === serverId) ||
+        (await Becca.guilds.fetch(serverId));
       if (!guild) {
         continue;
       }
       const channel =
-        guild.channels.cache.find((el) => el.id === reactionRole.channelId) ||
-        (await guild.channels.fetch(reactionRole.channelId));
+        guild.channels.cache.find((el) => el.id === channelId) ||
+        (await guild.channels.fetch(channelId));
       if (!channel) {
         continue;
       }
-      const message = await (channel as TextChannel).messages.fetch(
-        reactionRole.messageId
-      );
+      const message = await (channel as TextChannel).messages.fetch(messageId);
+      cacheMap.add(`${serverId}/${channelId}/${messageId}`);
       if (!message) {
         continue;
       }


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

Use a `Set` to ensure we don't fetch the same message more than once (for multiple reaction roles on a single message).
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://www.beccalyria.com/discord-documentation) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [X] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
