### PR TITLE
feat: send log embed if member is pending when removed

### DIFF
--- a/src/events/memberEvents/memberRemove.ts
+++ b/src/events/memberEvents/memberRemove.ts
@@ -5,6 +5,7 @@ import { defaultServer } from "../../config/database/defaultServer";
 import ServerModel from "../../database/models/ServerConfigModel";
 import { BeccaLyria } from "../../interfaces/BeccaLyria";
 import { memberRemoveCleanup } from "../../modules/guild/memberRemoveCleanup";
+import { sendLogEmbed } from "../../modules/guild/sendLogEmbed";
 import { sendWelcomeEmbed } from "../../modules/guild/sendWelcomeEmbed";
 import { beccaErrorHandler } from "../../utils/beccaErrorHandler";
 
@@ -20,7 +21,7 @@ export const memberRemove = async (
   member: GuildMember | PartialGuildMember
 ): Promise<void> => {
   try {
-    const { user, guild, nickname, roles } = member;
+    const { user, guild, nickname, roles, pending } = member;
 
     if (!user) {
       return;
@@ -53,7 +54,10 @@ export const memberRemove = async (
     goodbyeEmbed.setFooter(`ID: ${user.id}`);
     goodbyeEmbed.setTimestamp();
 
-    await sendWelcomeEmbed(Becca, guild, "leave", goodbyeEmbed);
+    pending
+      ? await sendLogEmbed(Becca, guild, goodbyeEmbed, "member_events")
+      : await sendWelcomeEmbed(Becca, guild, "leave", goodbyeEmbed);
+
     await memberRemoveCleanup(Becca, member.id, guild.id);
 
     Becca.pm2.metrics.users.set(Becca.pm2.metrics.users.val() - 1);


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

This PR changes the member leave flow. If a member is `pending` (has not completed the server verification), rather than sending the leave message in the departure channel, send it in the member events log channel.

<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #1197 

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [X] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
