### PR TITLE
feat: add emote fallbacks

### DIFF
--- a/src/listeners/beccaMentionListener.ts
+++ b/src/listeners/beccaMentionListener.ts
@@ -16,7 +16,9 @@ export const beccaMentionListener: Listener = {
         return;
       }
 
-      await message.react(Becca.configs.think);
+      await message
+        .react(Becca.configs.think)
+        .catch(async () => await message.react("🤔"));
       await channel.send(t("listeners:becca.response"));
     } catch (err) {
       await beccaErrorHandler(

--- a/src/listeners/heartsListener.ts
+++ b/src/listeners/heartsListener.ts
@@ -17,7 +17,9 @@ export const heartsListener: Listener = {
       const { author } = message;
       const usersToHeart = defaultHearts.concat(config.hearts);
       if (usersToHeart.includes(author.id)) {
-        await message.react(Becca.configs.love);
+        await message
+          .react(Becca.configs.love)
+          .catch(async () => await message.react("💜"));
       }
     } catch (err) {
       await beccaErrorHandler(

--- a/src/modules/commands/subcommands/community/handleSuggest.ts
+++ b/src/modules/commands/subcommands/community/handleSuggest.ts
@@ -63,8 +63,12 @@ export const handleSuggest: CommandHandler = async (
     const sentMessage = await suggestionChannel.send({
       embeds: [suggestionEmbed],
     });
-    await sentMessage.react(Becca.configs.yes);
-    await sentMessage.react(Becca.configs.no);
+    await sentMessage
+      .react(Becca.configs.yes)
+      .catch(async () => await sentMessage.react("✅"));
+    await sentMessage
+      .react(Becca.configs.no)
+      .catch(async () => await sentMessage.react("❌"));
 
     await interaction.editReply({
       content: t("commands:community.suggest.success"),


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

Adds `.catch` statements to the few reaction calls Becca makes, attempting another reaction with a fallback default emote.

The purpose of this is to use custom emotes through the `.env` settings again, while suppressing error logs for servers that did not grant the use external emote permission.

<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
