### PR TITLE
feat: deprecate self-assignable roles

### DIFF
--- a/src/config/commands/settingsChoices.ts
+++ b/src/config/commands/settingsChoices.ts
@@ -15,7 +15,6 @@ export const configChoices: [string, Settings][] = [
   ["Custom Welcome Message", "custom_welcome"],
   ["Heart Users", "hearts"],
   ["Blocked Users", "blocked"],
-  ["Self-assignable Roles", "self_roles"],
   ["Level-assigned Roles", "level_roles"],
   ["Role on Join", "join_role"],
   ["Custom Leave Message", "leave_message"],
@@ -30,7 +29,6 @@ export const configViewChoices: [string, ArraySettings | "global"][] = [
   ["Global Settings", "global"],
   // global must be on top for tests to pass
   ["Heart Users", "hearts"],
-  ["Self-Assignable Roles", "self_roles"],
   ["Blocked Users", "blocked"],
   ["Level-assigned Roles", "level_roles"],
   ["No Levelling Channels", "level_ignore"],

--- a/src/config/database/defaultServer.ts
+++ b/src/config/database/defaultServer.ts
@@ -15,7 +15,6 @@ export const defaultServer = {
     "Hello {@username}! Welcome to {@servername}! My name is Becca. Feel free to let me know if you need anything.",
   hearts: [] as string[],
   blocked: [] as string[],
-  self_roles: [] as string[],
   triggers: [] as [string, string][],
   automod_channels: [] as string[],
   no_automod_channels: [] as string[],

--- a/src/config/i18n/en-GB/commands.json
+++ b/src/config/i18n/en-GB/commands.json
@@ -235,13 +235,7 @@
       "results": "Results!"
     },
     "role": {
-      "none": "Your guild does not have any self assignable titles.",
-      "title": "Here are the titles I can grant you!",
-      "page": "Page {{page}} of {{last}}",
-      "invalid": "I cannot cast that enchantment. You will need to speak to someone higher up.",
-      "error": "Something is wrong with your role data...",
-      "removed": "You are no longer enchanted with {{name}}.",
-      "added": "I have cast the {{name}} charm on you."
+      "deprecated": "This command has been deprecated in favour of reaction roles. If your server does not have reaction roles set up, ask an admin to configure them!"
     },
     "schedule": {
       "permission": "You are not allowed to send messages in that channel.",

--- a/src/database/models/ServerConfigModel.ts
+++ b/src/database/models/ServerConfigModel.ts
@@ -17,7 +17,6 @@ export const ServerConfigSchema = new Schema({
   custom_welcome: String,
   hearts: [String],
   blocked: [String],
-  self_roles: [String],
   level_roles: [Object],
   join_role: String,
   leave_message: String,

--- a/src/interfaces/database/ServerConfig.ts
+++ b/src/interfaces/database/ServerConfig.ts
@@ -14,7 +14,6 @@ export interface ServerConfig extends Document {
   custom_welcome: string;
   hearts: string[];
   blocked: string[];
-  self_roles: string[];
   triggers: [string, string][];
   automod_channels: string[];
   no_automod_channels: string[];
@@ -51,7 +50,6 @@ export const testServerConfig: Omit<ServerConfig, keyof Document> = {
   custom_welcome: "",
   hearts: [],
   blocked: [],
-  self_roles: [],
   triggers: [],
   automod_channels: [],
   no_automod_channels: [],

--- a/src/interfaces/settings/ArraySettings.ts
+++ b/src/interfaces/settings/ArraySettings.ts
@@ -4,7 +4,6 @@
 export type ArraySettings =
   | "hearts"
   | "blocked"
-  | "self_roles"
   | "automod_channels"
   | "no_automod_channels"
   | "automod_roles"

--- a/src/interfaces/settings/Settings.ts
+++ b/src/interfaces/settings/Settings.ts
@@ -11,7 +11,6 @@ export type Settings =
   | "custom_welcome"
   | "hearts"
   | "blocked"
-  | "self_roles"
   | "automod_channels"
   | "no_automod_channels"
   | "automod_roles"

--- a/src/modules/commands/config/viewSettings.ts
+++ b/src/modules/commands/config/viewSettings.ts
@@ -103,11 +103,6 @@ export const viewSettings = async (
       true
     );
     settingsEmbed.addField(
-      t("commands:config.view.selfrole"),
-      config.self_roles.length.toString(),
-      true
-    );
-    settingsEmbed.addField(
       t("commands:config.view.emote"),
       config.emote_channels.length.toString(),
       true

--- a/src/modules/commands/subcommands/community/handleRole.ts
+++ b/src/modules/commands/subcommands/community/handleRole.ts
@@ -1,16 +1,6 @@
 /* eslint-disable jsdoc/require-param */
-import {
-  Message,
-  MessageActionRow,
-  MessageButton,
-  MessageEmbed,
-  Role,
-} from "discord.js";
-
 import { CommandHandler } from "../../../../interfaces/commands/CommandHandler";
 import { beccaErrorHandler } from "../../../../utils/beccaErrorHandler";
-import { getRandomValue } from "../../../../utils/getRandomValue";
-import { sleep } from "../../../../utils/sleep";
 import { errorEmbedGenerator } from "../../../commands/errorEmbedGenerator";
 
 /**
@@ -22,140 +12,11 @@ import { errorEmbedGenerator } from "../../../commands/errorEmbedGenerator";
 export const handleRole: CommandHandler = async (
   Becca,
   interaction,
-  t,
-  config
+  t
 ): Promise<void> => {
   try {
-    const { guild, member } = interaction;
-
-    if (!guild || !member) {
-      await interaction.editReply({
-        content: getRandomValue(t("responses:missingGuild")),
-      });
-      return;
-    }
-
-    const targetRole = interaction.options.getRole("role");
-
-    if (!targetRole) {
-      if (!config.self_roles.length) {
-        await interaction.editReply({
-          content: t("commands:community.role.none"),
-        });
-        return;
-      }
-      let page = 1;
-      const roleList = config.self_roles.map((role) => `<@&${role}>`);
-      const lastPage = Math.ceil(roleList.length / 10);
-
-      const embed = new MessageEmbed();
-      embed.setTitle(t("commands:community.role.title"));
-      embed.setDescription(
-        roleList.slice(page * 10 - 10, page * 10).join("\n")
-      );
-      embed.setFooter(`Page ${page} of ${lastPage}`);
-
-      const pageBack = new MessageButton()
-        .setCustomId("prev")
-        .setDisabled(true)
-        .setLabel("◀")
-        .setStyle("PRIMARY");
-      const pageForward = new MessageButton()
-        .setCustomId("next")
-        .setLabel("▶")
-        .setStyle("PRIMARY");
-
-      if (lastPage === 1) {
-        pageForward.setDisabled(true);
-      }
-
-      const sent = (await interaction.editReply({
-        embeds: [embed],
-        components: [
-          new MessageActionRow().addComponents(pageBack, pageForward),
-        ],
-      })) as Message;
-
-      const clickyClick = sent.createMessageComponentCollector({
-        time: 30000,
-        filter: (click) => click.user.id === interaction.user.id,
-      });
-
-      clickyClick.on("collect", async (click) => {
-        click.deferUpdate();
-        if (click.customId === "prev") {
-          page--;
-        }
-        if (click.customId === "next") {
-          page++;
-        }
-
-        if (page <= 1) {
-          pageBack.setDisabled(true);
-        } else {
-          pageBack.setDisabled(false);
-        }
-        if (page >= lastPage) {
-          pageForward.setDisabled(true);
-        } else {
-          pageForward.setDisabled(false);
-        }
-
-        embed.setDescription(
-          roleList.slice(page * 10 - 10, page * 10).join("\n")
-        );
-        embed.setFooter(
-          t("commands:community.role.page", { page, last: lastPage })
-        );
-
-        await interaction.editReply({
-          embeds: [embed],
-          components: [
-            new MessageActionRow().addComponents(pageBack, pageForward),
-          ],
-        });
-      });
-
-      clickyClick.on("end", async () => {
-        pageBack.setDisabled(true);
-        pageForward.setDisabled(true);
-        await interaction.editReply({
-          components: [
-            new MessageActionRow().addComponents(pageBack, pageForward),
-          ],
-        });
-      });
-
-      await sleep(35000);
-      return;
-    }
-
-    if (!config.self_roles.includes(targetRole.id)) {
-      await interaction.editReply({
-        content: t("commands:community.role.invalid"),
-      });
-      return;
-    }
-
-    if (Array.isArray(member.roles)) {
-      await interaction.editReply({
-        content: t("commands:community.role.error"),
-      });
-      return;
-    }
-
-    if (member.roles.cache.has(targetRole.id)) {
-      await member.roles.remove(targetRole as Role);
-      await interaction.editReply({
-        content: t("commands:community.role.removed", {
-          name: targetRole.name,
-        }),
-      });
-      return;
-    }
-    await member.roles.add(targetRole as Role);
     await interaction.editReply({
-      content: t("commands:community.role.added", { name: targetRole.name }),
+      content: t("commands:community.role.deprecated"),
     });
   } catch (err) {
     const errorId = await beccaErrorHandler(

--- a/src/modules/settings/renderSetting.ts
+++ b/src/modules/settings/renderSetting.ts
@@ -49,7 +49,6 @@ export const renderSetting = (
       case "hearts":
       case "blocked":
         return `<@!${value}>`;
-      case "self_roles":
       case "automod_roles":
       case "join_role":
         return `<@&${value}>`;

--- a/src/modules/settings/setSetting.ts
+++ b/src/modules/settings/setSetting.ts
@@ -46,7 +46,6 @@ export const setSetting = async (
         break;
       case "hearts":
       case "blocked":
-      case "self_roles":
       case "automod_roles":
       case "level_ignore":
       case "emote_channels":

--- a/src/modules/settings/validateSetting.ts
+++ b/src/modules/settings/validateSetting.ts
@@ -43,7 +43,6 @@ export const validateSetting = async (
         );
       case "join_role":
         return !!parsedValue && !!(await guild.roles.fetch(`${parsedValue}`));
-      case "self_roles":
       case "automod_roles":
         return (
           !!parsedValue &&


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

Deprecates the `/community role` command in favour of the reaction role system, to reduce load on the database.

<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [X] My contribution DOES require a documentation update.
