### PR TITLE
fix: correct heptagram api url

### DIFF
--- a/src/listeners/automod/automodPhish.ts
+++ b/src/listeners/automod/automodPhish.ts
@@ -48,7 +48,7 @@ export const automodPhish: ListenerHandler = async (
 
     for (const link of blockedLinkList) {
       const checkHeptagramAPI = await axios.get<boolean>(
-        `http://heptagrambotproject.com/api/v0/api/scam/link/check?url=${link}`,
+        `http://api.heptagrambotproject.com/api/v0/api/scam/link/check?url=${link}`,
         {
           // send authentication header
           headers: {


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

Use the correct URL.
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [X] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
