### PR TITLE
feat: make role/level messages configurable

### DIFF
--- a/src/config/commands/settingsChoices.ts
+++ b/src/config/commands/settingsChoices.ts
@@ -26,6 +26,9 @@ export const configChoices: APIApplicationCommandOptionChoice<Settings>[] = [
   { name: "Sass Mode", value: "sass_mode" },
   { name: "Emote-Only Channels", value: "emote_channels" },
   { name: "Initial Experience", value: "initial_xp" },
+  { name: "Level Message Style", value: "level_style" },
+  { name: "Level Message", value: "level_message" },
+  { name: "Role Message", value: "role_message" },
 ];
 
 export const configViewChoices: APIApplicationCommandOptionChoice<

--- a/src/config/database/defaultServer.ts
+++ b/src/config/database/defaultServer.ts
@@ -42,4 +42,7 @@ export const defaultServer = {
   appeal_link: "",
   antiphish: "none",
   initial_xp: "0",
+  level_style: "embed",
+  level_message: "",
+  role_message: "",
 };

--- a/src/config/i18n/en-GB/commands.json
+++ b/src/config/i18n/en-GB/commands.json
@@ -347,7 +347,11 @@
       "blocked": "Blocked User Count",
       "selfrole": "Self Assignable Titles",
       "emote": "Emote Only Channels",
-      "ban": "Ban Appeal Link"
+      "ban": "Ban Appeal Link",
+      "initialXp": "Initial Experience",
+      "levelStyle": "Level Messages Style",
+      "levelMessage": "Level Message",
+      "roleMessage": "Role Message"
     },
     "settingsArray": {
       "title": "Config data for {{setting}}",

--- a/src/database/models/ServerConfigModel.ts
+++ b/src/database/models/ServerConfigModel.ts
@@ -49,6 +49,12 @@ export const ServerConfigSchema = new Schema({
     type: String,
     default: "0",
   },
+  level_style: {
+    type: String,
+    default: "embed",
+  },
+  level_message: String,
+  role_message: String,
 });
 
 export default model<ServerConfig>("server", ServerConfigSchema);

--- a/src/interfaces/database/ServerConfig.ts
+++ b/src/interfaces/database/ServerConfig.ts
@@ -38,6 +38,9 @@ export interface ServerConfig extends Document {
   appeal_link: string;
   antiphish: "none" | "mute" | "kick" | "ban";
   initial_xp: string;
+  level_style: "embed" | "text";
+  level_message: string;
+  role_message: string;
 }
 
 export const testServerConfig: Omit<ServerConfig, keyof Document> = {
@@ -75,4 +78,7 @@ export const testServerConfig: Omit<ServerConfig, keyof Document> = {
   appeal_link: "",
   antiphish: "none",
   initial_xp: "0",
+  level_message: "",
+  level_style: "embed",
+  role_message: "",
 };

--- a/src/interfaces/settings/Settings.ts
+++ b/src/interfaces/settings/Settings.ts
@@ -33,4 +33,7 @@ export type Settings =
   | "emote_channels"
   | "appeal_link"
   | "antiphish"
-  | "initial_xp";
+  | "initial_xp"
+  | "level_style"
+  | "level_message"
+  | "role_message";

--- a/src/modules/commands/config/viewSettings.ts
+++ b/src/modules/commands/config/viewSettings.ts
@@ -127,6 +127,28 @@ export const viewSettings = async (
         value: config.initial_xp,
         inline: true,
       },
+      {
+        name: t("commands:config.view.levelStyle"),
+        value: config.level_style,
+        inline: true,
+      },
+      {
+        name: t("commands:config.view.levelMessage"),
+        value: customSubstring(
+          config.level_message ||
+            t("listeners:level.desc", { user: "{@user}", level: "{level}" }),
+          1000
+        ),
+      },
+      {
+        name: t("commands:config.view.roleMessage"),
+        value: customSubstring(
+          config.role_message ||
+            t("listeners:level.roleDesc", { user: "{@user}", role: "{@role}" }),
+          1000
+        ),
+        inline: true,
+      },
     ]);
     settingsEmbed.setFooter({
       text: t("defaults:donate"),

--- a/src/modules/listeners/generateLevelText.ts
+++ b/src/modules/listeners/generateLevelText.ts
@@ -1,0 +1,20 @@
+import { User } from "discord.js";
+
+/**
+ * Generates level text from a given template.
+ *
+ * @param {string} template The template to use.
+ * @param {User} user The user that levelled up.
+ * @param {number} level The user's new level.
+ * @returns {string} The generated level text.
+ */
+export const generateLevelText = (
+  template: string,
+  user: User,
+  level: number
+): string => {
+  return template
+    .replace(/\{user\}/g, user.tag)
+    .replace(/\{level\}/g, level.toString())
+    .replace(/\{@user}/g, `<@${user.id}>`);
+};

--- a/src/modules/listeners/generateRoleText.ts
+++ b/src/modules/listeners/generateRoleText.ts
@@ -1,0 +1,21 @@
+import { Role, User } from "discord.js";
+
+/**
+ * Generates role text from a given template.
+ *
+ * @param {string} template The template to use.
+ * @param {User} user The user that levelled up.
+ * @param {Role} role The user's new role.
+ * @returns {string} The generated level text.
+ */
+export const generateRoleText = (
+  template: string,
+  user: User,
+  role: Role
+): string => {
+  return template
+    .replace(/\{user\}/g, user.tag)
+    .replace(/\{role\}/g, role.name)
+    .replace(/\{@user}/g, `<@${user.id}>`)
+    .replace(/\{@role\}/g, `<@&${role.id}>`);
+};

--- a/src/modules/settings/renderSetting.ts
+++ b/src/modules/settings/renderSetting.ts
@@ -34,6 +34,9 @@ export const renderSetting = (
       case "appeal_link":
       case "antiphish":
       case "initial_xp":
+      case "level_style":
+      case "level_message":
+      case "role_message":
         return value as string;
       case "welcome_channel":
       case "depart_channel":

--- a/src/modules/settings/setSetting.ts
+++ b/src/modules/settings/setSetting.ts
@@ -93,10 +93,15 @@ export const setSetting = async (
       case "profanity_message":
       case "appeal_link":
       case "initial_xp":
+      case "level_message":
+      case "role_message":
         server[key] = value;
         break;
       case "antiphish":
         server[key] = value as "none" | "mute" | "kick" | "ban";
+        break;
+      case "level_style":
+        server[key] = value as "embed" | "text";
         break;
       case "welcome_channel":
       case "depart_channel":

--- a/src/modules/settings/validateSetting.ts
+++ b/src/modules/settings/validateSetting.ts
@@ -95,6 +95,8 @@ export const validateSetting = async (
         );
       case "initial_xp":
         return !isNaN(parseInt(value)) && parseInt(value) >= 0;
+      case "level_style":
+        return value === "embed" || value === "text";
       case "allowed_links":
       case "appeal_link":
       case "antiphish":
@@ -102,6 +104,8 @@ export const validateSetting = async (
       case "link_message":
       case "leave_message":
       case "profanity_message":
+      case "level_message":
+      case "role_message":
         return true;
       default:
         return false;


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

This makes the level up responses configurable.

- Servers can set a custom level up message where:
  - `{user}` is replaced with the user's tag
  - `{@user}` is replaced with the user mention
  - `{level}` is replaced with the user's level
- Servers can set a custom level role gain message where:
  - `{user}` is replaced with the user's tag
  - `{@user}` is replaced with the user mention
  - `{role}` is replaced with the role's name
  - `{@role}` is replaced with the role mention
- Servers can toggle between `embed` and `text` style messages.
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [X] My contribution DOES require a documentation update.
