### PR TITLE
fix: timestamp logic in currency view

### DIFF
--- a/src/commands/subcommands/currency/handleView.ts
+++ b/src/commands/subcommands/currency/handleView.ts
@@ -18,12 +18,6 @@ export const handleView: CurrencyHandler = async (
   try {
     const { user } = interaction;
     const now = Date.now();
-    const dailyCooldown = Math.round(
-      new Date(data.dailyClaimed - now + 86400000).getTime() / 1000
-    );
-    const weeklyCooldown = Math.round(
-      new Date(data.weeklyClaimed - now + 604800000).getTime() / 1000
-    );
 
     const viewEmbed = new EmbedBuilder();
     viewEmbed.setTitle("Currency Report");
@@ -36,13 +30,17 @@ export const handleView: CurrencyHandler = async (
       {
         name: t("commands:currency.view.daily"),
         value:
-          dailyCooldown - Date.now() <= 0 ? "now!" : `<t:${dailyCooldown}:R>`,
+          data.dailyClaimed + 86400000 < now
+            ? "now!"
+            : `<t:${Math.round((data.dailyClaimed + 86400000) / 1000)}:R>`,
         inline: true,
       },
       {
         name: t("commands:currency.view.weekly"),
         value:
-          weeklyCooldown - Date.now() <= 0 ? "now!" : `<t:${weeklyCooldown}:R>`,
+          data.weeklyClaimed + 604800000 < now
+            ? "now!"
+            : `<t:${Math.round((data.weeklyClaimed + 604800000) / 1000)}:R>`,
         inline: true,
       },
     ]);


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

`dailyCooldown` and `weeklyCooldown` were representing the number of seconds before the user could claim the reward again. This was intended to run in the `parseSeconds` function.

Since we moved to timestamps, we don't need the number of seconds here - instead, we just check if the cooldown is earlier than Date.now().
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [X] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
