### PR TITLE
fix: add automod links and profanity subcommands

### DIFF
--- a/src/commands/automod.ts
+++ b/src/commands/automod.ts
@@ -114,6 +114,32 @@ const subcommands = [
           { name: "Ban the user.", value: "ban" }
         )
     ),
+  new SlashCommandSubcommandBuilder()
+    .setName("links")
+    .setDescription("Toggle Link Detection")
+    .addStringOption((option) =>
+      option
+        .setName("value")
+        .setDescription("Enable/Disable the setting.")
+        .setRequired(true)
+        .addChoices(
+          { name: "Enabled", value: "on" },
+          { name: "Disabled", value: "off" }
+        )
+    ),
+  new SlashCommandSubcommandBuilder()
+    .setName("profanity")
+    .setDescription("Toggle Profanity Detection")
+    .addStringOption((option) =>
+      option
+        .setName("value")
+        .setDescription("Enable/Disable the setting.")
+        .setRequired(true)
+        .addChoices(
+          { name: "Enabled", value: "on" },
+          { name: "Disabled", value: "off" }
+        )
+    ),
 ];
 
 export const automod: Command = {


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description
This PR adds the subcommand `links` and `profanity` for the `automod` command, so that the system can be toggled on and off. These were lost during the config overhaul (https://github.com/BeccaLyria/discord-bot/commit/a6515e95356e03e1dc9526e4dd67485404d6d74b#diff-ce069ee9d6e6d976c4684b24a1094617a768d4a0093dcffc74d371729ca983f3L81-L102).
<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [x] My contribution DOES require a documentation update.
<img width="1072" alt="Screenshot 2022-11-28 at 4 35 40 AM" src="https://user-images.githubusercontent.com/62864373/204164572-2dfcb4da-39ce-44a9-a53c-ea4a79f20085.png">


