### PR TITLE
fix: change automod set toggle

### DIFF
--- a/src/commands/automod.ts
+++ b/src/commands/automod.ts
@@ -119,26 +119,20 @@ const subcommands = [
     .setDescription("Toggle Link Detection")
     .addStringOption((option) =>
       option
-        .setName("value")
+        .setName("toggle")
         .setDescription("Enable/Disable the setting.")
         .setRequired(true)
-        .addChoices(
-          { name: "Enabled", value: "on" },
-          { name: "Disabled", value: "off" }
-        )
+        .addChoices({ name: "on", value: "on" }, { name: "off", value: "off" })
     ),
   new SlashCommandSubcommandBuilder()
     .setName("profanity")
     .setDescription("Toggle Profanity Detection")
     .addStringOption((option) =>
       option
-        .setName("value")
+        .setName("toggle")
         .setDescription("Enable/Disable the setting.")
         .setRequired(true)
-        .addChoices(
-          { name: "Enabled", value: "on" },
-          { name: "Disabled", value: "off" }
-        )
+        .addChoices({ name: "on", value: "on" }, { name: "off", value: "off" })
     ),
 ];
 


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

<!-- A brief description of what your pull request does. -->
This PR changes the option field name for the `/automod set links` and `/automod set profanity` to `toggle`, in order to be consistent across the documentation and match the toggle setting commands like `/levels set levels` and `/levels set level_style`.

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
