### PR TITLE
Chore: Use timestamps for currency commands

### DIFF
--- a/src/commands/subcommands/currency/handleDaily.ts
+++ b/src/commands/subcommands/currency/handleDaily.ts
@@ -1,10 +1,9 @@
 /* eslint-disable jsdoc/require-param */
-import { EmbedBuilder } from "discord.js";
+import { EmbedBuilder, TimestampStyles, time } from "discord.js";
 
 import { CurrencyHandler } from "../../../interfaces/commands/CurrencyHandler";
 import { errorEmbedGenerator } from "../../../modules/commands/errorEmbedGenerator";
 import { beccaErrorHandler } from "../../../utils/beccaErrorHandler";
-import { parseSeconds } from "../../../utils/parseSeconds";
 import { scheduleCurrencyReminder } from "../../../utils/scheduleCurrencyReminder";
 
 /**
@@ -23,10 +22,13 @@ export const handleDaily: CurrencyHandler = async (
 
     if (!canClaim) {
       const cooldown = data.dailyClaimed - now + 86400000;
+      const cooldownDate = new Date(data.dailyClaimed + cooldown);
+      const remainingTimeDesc = t("commands:currency.daily.cooldown", {
+        time: time(cooldownDate, TimestampStyles.RelativeTime),
+        interpolation: { escapeValue: false },
+      });
       await interaction.editReply({
-        content: t("commands:currency.daily.cooldown", {
-          time: parseSeconds(Math.ceil(cooldown / 1000)),
-        }),
+        content: remainingTimeDesc,
       });
       return;
     }

--- a/src/commands/subcommands/currency/handleSlots.ts
+++ b/src/commands/subcommands/currency/handleSlots.ts
@@ -1,12 +1,11 @@
 /* eslint-disable jsdoc/require-param */
-import { EmbedBuilder } from "discord.js";
+import { EmbedBuilder, time, TimestampStyles } from "discord.js";
 
 import { slotsList } from "../../../config/commands/slotsList";
 import { CurrencyHandler } from "../../../interfaces/commands/CurrencyHandler";
 import { errorEmbedGenerator } from "../../../modules/commands/errorEmbedGenerator";
 import { beccaErrorHandler } from "../../../utils/beccaErrorHandler";
 import { getRandomValue } from "../../../utils/getRandomValue";
-import { parseSeconds } from "../../../utils/parseSeconds";
 
 /**
  * Confirms that the user has not used this command within the last hour, then
@@ -37,10 +36,13 @@ export const handleSlots: CurrencyHandler = async (
 
     if (!canPlay) {
       const cooldown = data.slotsPlayed - now + 3600000;
+      const cooldownDate = new Date(data.slotsPlayed + cooldown);
+      const remainingTimeDesc = t("commands:currency.slots.cooldown", {
+        time: time(cooldownDate, TimestampStyles.RelativeTime),
+        interpolation: { escapeValue: false },
+      });
       await interaction.editReply({
-        content: t("commands:currency.slots.cooldown", {
-          time: parseSeconds(Math.ceil(cooldown / 1000)),
-        }),
+        content: remainingTimeDesc,
       });
       return;
     }

--- a/src/commands/subcommands/currency/handleTwentyOne.ts
+++ b/src/commands/subcommands/currency/handleTwentyOne.ts
@@ -5,12 +5,13 @@ import {
   ButtonStyle,
   EmbedBuilder,
   Message,
+  time,
+  TimestampStyles,
 } from "discord.js";
 
 import { CurrencyHandler } from "../../../interfaces/commands/CurrencyHandler";
 import { errorEmbedGenerator } from "../../../modules/commands/errorEmbedGenerator";
 import { beccaErrorHandler } from "../../../utils/beccaErrorHandler";
-import { parseSeconds } from "../../../utils/parseSeconds";
 
 /**
  * Allows a user to play a game of 21 with Becca, similar to Blackjack. If the user
@@ -43,10 +44,13 @@ export const handleTwentyOne: CurrencyHandler = async (
 
     if (!canPlay) {
       const cooldown = data.twentyOnePlayed - now + 3600000;
+      const cooldownDate = new Date(data.slotsPlayed + cooldown);
+      const remainingTimeDesc = t("commands:currency.twentyone.cooldown", {
+        time: time(cooldownDate, TimestampStyles.RelativeTime),
+        interpolation: { escapeValue: false },
+      });
       await interaction.editReply({
-        content: t("commands:currency.twentyone.cooldown", {
-          time: parseSeconds(Math.ceil(cooldown / 1000)),
-        }),
+        content: remainingTimeDesc,
       });
       return;
     }

--- a/src/commands/subcommands/currency/handleWeekly.ts
+++ b/src/commands/subcommands/currency/handleWeekly.ts
@@ -1,10 +1,9 @@
 /* eslint-disable jsdoc/require-param */
-import { EmbedBuilder } from "discord.js";
+import { EmbedBuilder, TimestampStyles, time } from "discord.js";
 
 import { CurrencyHandler } from "../../../interfaces/commands/CurrencyHandler";
 import { errorEmbedGenerator } from "../../../modules/commands/errorEmbedGenerator";
 import { beccaErrorHandler } from "../../../utils/beccaErrorHandler";
-import { parseSeconds } from "../../../utils/parseSeconds";
 import { scheduleCurrencyReminder } from "../../../utils/scheduleCurrencyReminder";
 
 /**
@@ -39,10 +38,13 @@ export const handleWeekly: CurrencyHandler = async (
 
     if (!canClaim) {
       const cooldown = data.weeklyClaimed - now + 604800000;
+      const cooldownDate = new Date(data.weeklyClaimed + cooldown);
+      const remainingTimeDesc = t("commands:currency.weekly.cooldown", {
+        time: time(cooldownDate, TimestampStyles.RelativeTime),
+        interpolation: { escapeValue: false },
+      });
       await interaction.editReply({
-        content: t("commands:currency.weekly.cooldown", {
-          time: parseSeconds(Math.ceil(cooldown / 1000)),
-        }),
+        content: remainingTimeDesc,
       });
       return;
     }


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

<!-- A brief description of what your pull request does. -->
It modified the handleDaily, handSlots, handleTwentyOne, and handleWeekly sub commands in the currency command to use Discord's timestamp feature.  

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes  #1596

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [X] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.

As an aside, I remember seeing Discord's timestamp system used manually in the codebase. I think it'd be more legible if the function was used instead, but it is outside of the scope of this PR. 
