### PR TITLE
Chore: Remove magic numbers and try to fix currency reminders.

### DIFF
--- a/src/commands/subcommands/currency/handleDaily.ts
+++ b/src/commands/subcommands/currency/handleDaily.ts
@@ -16,11 +16,14 @@ export const handleDaily: CurrencyHandler = async (
   data
 ) => {
   try {
+    const dayInMilliseconds = 86400000;
     const now = Date.now();
-    const canClaim = now - 86400000 > data.dailyClaimed;
+    //Has it been more than a day since they last claimed.
+    const canClaim = now - dayInMilliseconds > data.dailyClaimed;
 
     if (!canClaim) {
-      const cooldown = data.dailyClaimed - now + 86400000;
+      // Determine what day it'll be when they can claim again
+      const cooldown = data.dailyClaimed + dayInMilliseconds;
       const cooldownDate = new Date(data.dailyClaimed + cooldown);
       const remainingTimeDesc = t("commands:currency.daily.cooldown", {
         time: time(cooldownDate, TimestampStyles.RelativeTime),
@@ -48,7 +51,7 @@ export const handleDaily: CurrencyHandler = async (
 
     await scheduleCurrencyReminder(
       Becca,
-      86400000,
+      dayInMilliseconds,
       t("commands:currency.daily.reminder", {
         user: `<@!${data.userId}>`,
       })

--- a/src/commands/subcommands/currency/handleDaily.ts
+++ b/src/commands/subcommands/currency/handleDaily.ts
@@ -24,7 +24,7 @@ export const handleDaily: CurrencyHandler = async (
     if (!canClaim) {
       // Determine what day it'll be when they can claim again
       const cooldown = data.dailyClaimed + dayInMilliseconds;
-      const cooldownDate = new Date(data.dailyClaimed + cooldown);
+      const cooldownDate = new Date(cooldown);
       const remainingTimeDesc = t("commands:currency.daily.cooldown", {
         time: time(cooldownDate, TimestampStyles.RelativeTime),
         interpolation: { escapeValue: false },

--- a/src/commands/subcommands/currency/handleSlots.ts
+++ b/src/commands/subcommands/currency/handleSlots.ts
@@ -18,6 +18,8 @@ export const handleSlots: CurrencyHandler = async (
   data
 ) => {
   try {
+    const hourInMillseconds = 3600000;
+
     const wager = interaction.options.getInteger("wager");
 
     if (!wager || wager < 1) {
@@ -31,10 +33,10 @@ export const handleSlots: CurrencyHandler = async (
     }
 
     const now = Date.now();
-    const canPlay = now - 3600000 > data.slotsPlayed;
+    const canPlay = now - hourInMillseconds > data.slotsPlayed;
 
     if (!canPlay) {
-      const cooldown = data.slotsPlayed - now + 3600000;
+      const cooldown = data.slotsPlayed + hourInMillseconds;
       const cooldownDate = new Date(data.slotsPlayed + cooldown);
       const remainingTimeDesc = t("commands:currency.slots.cooldown", {
         time: time(cooldownDate, TimestampStyles.RelativeTime),

--- a/src/commands/subcommands/currency/handleSlots.ts
+++ b/src/commands/subcommands/currency/handleSlots.ts
@@ -37,7 +37,7 @@ export const handleSlots: CurrencyHandler = async (
 
     if (!canPlay) {
       const cooldown = data.slotsPlayed + hourInMillseconds;
-      const cooldownDate = new Date(data.slotsPlayed + cooldown);
+      const cooldownDate = new Date(cooldown);
       const remainingTimeDesc = t("commands:currency.slots.cooldown", {
         time: time(cooldownDate, TimestampStyles.RelativeTime),
         interpolation: { escapeValue: false },

--- a/src/commands/subcommands/currency/handleTwentyOne.ts
+++ b/src/commands/subcommands/currency/handleTwentyOne.ts
@@ -76,6 +76,8 @@ export const handleTwentyOne: CurrencyHandler = async (
   data
 ) => {
   try {
+    const hourInMillseconds = 3600000;
+
     const wager = interaction.options.getInteger("wager");
 
     if (!wager || wager < 1) {
@@ -91,10 +93,10 @@ export const handleTwentyOne: CurrencyHandler = async (
     }
 
     const now = Date.now();
-    const canPlay = now - 3600000 > data.twentyOnePlayed;
+    const canPlay = now - hourInMillseconds > data.twentyOnePlayed;
 
     if (!canPlay) {
-      const cooldown = data.twentyOnePlayed - now + 3600000;
+      const cooldown = data.twentyOnePlayed + hourInMillseconds;
       const cooldownDate = new Date(data.twentyOnePlayed + cooldown);
       const remainingTimeDesc = t("commands:currency.twentyone.cooldown", {
         time: time(cooldownDate, TimestampStyles.RelativeTime),

--- a/src/commands/subcommands/currency/handleTwentyOne.ts
+++ b/src/commands/subcommands/currency/handleTwentyOne.ts
@@ -97,7 +97,7 @@ export const handleTwentyOne: CurrencyHandler = async (
 
     if (!canPlay) {
       const cooldown = data.twentyOnePlayed + hourInMillseconds;
-      const cooldownDate = new Date(data.twentyOnePlayed + cooldown);
+      const cooldownDate = new Date(cooldown);
       const remainingTimeDesc = t("commands:currency.twentyone.cooldown", {
         time: time(cooldownDate, TimestampStyles.RelativeTime),
         interpolation: { escapeValue: false },

--- a/src/commands/subcommands/currency/handleWeekly.ts
+++ b/src/commands/subcommands/currency/handleWeekly.ts
@@ -39,7 +39,7 @@ export const handleWeekly: CurrencyHandler = async (
 
     if (!canClaim) {
       const cooldown = data.weeklyClaimed + weekInMillseconds;
-      const cooldownDate = new Date(data.weeklyClaimed + cooldown);
+      const cooldownDate = new Date(cooldown);
       const remainingTimeDesc = t("commands:currency.weekly.cooldown", {
         time: time(cooldownDate, TimestampStyles.RelativeTime),
         interpolation: { escapeValue: false },

--- a/src/commands/subcommands/currency/handleWeekly.ts
+++ b/src/commands/subcommands/currency/handleWeekly.ts
@@ -16,8 +16,10 @@ export const handleWeekly: CurrencyHandler = async (
   data
 ) => {
   try {
+    const weekInMillseconds = 604800000;
+
     const now = Date.now();
-    const canClaim = now - 604800000 > data.weeklyClaimed;
+    const canClaim = now - weekInMillseconds > data.weeklyClaimed;
 
     const homeServer = await interaction.client.guilds.fetch(
       Becca.configs.homeGuild
@@ -36,7 +38,7 @@ export const handleWeekly: CurrencyHandler = async (
     }
 
     if (!canClaim) {
-      const cooldown = data.weeklyClaimed - now + 604800000;
+      const cooldown = data.weeklyClaimed + weekInMillseconds;
       const cooldownDate = new Date(data.weeklyClaimed + cooldown);
       const remainingTimeDesc = t("commands:currency.weekly.cooldown", {
         time: time(cooldownDate, TimestampStyles.RelativeTime),
@@ -64,7 +66,7 @@ export const handleWeekly: CurrencyHandler = async (
 
     await scheduleCurrencyReminder(
       Becca,
-      604800000,
+      weekInMillseconds,
       t("commands:currency.weekly.reminder", {
         user: `<@!${data.userId}>`,
       })


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

<!-- A brief description of what your pull request does. -->
It updates the codebase to no longer use magic numbers for remaining time in the currency commands and attempts to fix the invalid remaining usage time. 


## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [X] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
