### PR TITLE
feat: toggle analytics

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -25,3 +25,5 @@ BECCA_THINK=The ID of the emoiji to use for bot @mentions
 
 SENTRY_DSN=Project DSN from Sentry.io
 ANALYTICS_SECRET=Secret key for analytics server
+ANALYTICS_URL=URL for analytics server
+ANALYTICS_ENABLED=false

--- a/src/interfaces/BeccaLyria.ts
+++ b/src/interfaces/BeccaLyria.ts
@@ -36,6 +36,7 @@ export interface BeccaLyria extends Client {
     topGG: string;
     voteChannel: string;
     analyticsSecret: string;
+    analyticsUrl: string;
   };
   colours: {
     default: number;

--- a/src/modules/Analytics.ts
+++ b/src/modules/Analytics.ts
@@ -1,5 +1,7 @@
 import { WebhookClient } from "discord.js";
 
+import { beccaLogHandler } from "../utils/beccaLogHandler";
+
 /**
  * Handles processing all of Becca's analytics.
  *
@@ -7,16 +9,26 @@ import { WebhookClient } from "discord.js";
  */
 export class Analytics {
   private readonly _secret: string;
-  private readonly _url = "https://analytics.beccalyria.com";
+  private readonly _url: string;
+  private readonly _sendRequests: boolean;
   private readonly _errorHook: WebhookClient;
 
   /**
    * @param {string} secret The endpoint auth secret.
+   * @param {string} url The analytics server URL.
+   * @param {boolean} sendRequests If requests should be sent.
    * @param {WebhookClient} errors The error webhook.
    * @public
    */
-  constructor(secret: string, errors: WebhookClient) {
+  constructor(
+    secret: string,
+    url: string,
+    sendRequests: boolean,
+    errors: WebhookClient
+  ) {
     this._secret = secret;
+    this._url = url;
+    this._sendRequests = sendRequests;
     this._errorHook = errors;
   }
 
@@ -29,6 +41,10 @@ export class Analytics {
    * @async
    */
   private async makeRequest(endpoint: string, body: object): Promise<void> {
+    if (!this._sendRequests) {
+      beccaLogHandler.log("debug", `Analytics call to ${endpoint} suppressed.`);
+      return;
+    }
     const result = await fetch(`${this._url}/${endpoint}`, {
       method: "POST",
       headers: {

--- a/src/modules/prepareBecca.ts
+++ b/src/modules/prepareBecca.ts
@@ -32,6 +32,8 @@ export const prepareBecca = (Becca: BeccaLyria): void => {
   Becca.timeOuts = {};
   Becca.analytics = new Analytics(
     Becca.configs.analyticsSecret,
+    Becca.configs.analyticsUrl,
+    process.env.ANALYTICS_ENABLED === "true",
     Becca.debugHook
   );
 };

--- a/src/modules/validateEnv.ts
+++ b/src/modules/validateEnv.ts
@@ -57,11 +57,6 @@ export const validateEnv = (): BeccaLyria["configs"] => {
     process.exit(1);
   }
 
-  if (!process.env.ANALYTICS_SECRET) {
-    beccaLogHandler.log("error", "Missing Analytics Secret");
-    process.exit(1);
-  }
-
   return {
     token: process.env.DISCORD_TOKEN,
     dbToken: process.env.MONGODB,
@@ -81,6 +76,7 @@ export const validateEnv = (): BeccaLyria["configs"] => {
     topGGToken: process.env.TOPGG_TOKEN || "",
     topGG: process.env.TOPGG_PASSWORD || "",
     voteChannel: process.env.VOTE_CHANNEL_ID || "",
-    analyticsSecret: process.env.ANALYTICS_SECRET,
+    analyticsSecret: process.env.ANALYTICS_SECRET || "test_secret",
+    analyticsUrl: process.env.ANALYTICS_URL || "http://localhost:3000",
   };
 };


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://docs.beccalyria.com/#/contribute -->

## Description

Achieves a few things:
- Adds a toggle that suppresses the `fetch` calls in the analytics, and uses a log instead.
- Makes the `ANALYTICS_SECRET` optional.
- Adds an `ANALYTICS_URL` env to allow for local testing of the analytics server, if desired.

<!-- A brief description of what your pull request does. -->

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #XXXXX

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [X] My contribution DOES require a documentation update.
