### PR TITLE
fix: `/support server` command response

### DIFF
--- a/src/commands/subcommands/support/handleServer.ts
+++ b/src/commands/subcommands/support/handleServer.ts
@@ -8,7 +8,7 @@ import { beccaErrorHandler } from "../../../utils/beccaErrorHandler";
 export const handleServer: CommandHandler = async (Becca, interaction, t) => {
   try {
     await interaction.editReply({
-      content: t("commands:support.server"),
+      content: t("commands:support.server.response"),
     });
   } catch (err) {
     const errorId = await beccaErrorHandler(


### PR DESCRIPTION
# Pull Request

## Description

Fixes `/support server` response. At the moment, it pulls `commands:support.server` from `i18n`, when it should be pulling `commands:support.server.response`.

## Documentation

For _any_ version updates, please verify if the [documentation page](https://docs.beccalyria.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
